### PR TITLE
ci: simplify reseal-secrets.yml (kubectl dry-run instead of python)

### DIFF
--- a/.github/workflows/reseal-secrets.yml
+++ b/.github/workflows/reseal-secrets.yml
@@ -18,39 +18,27 @@ jobs:
 
       - name: Seal denpa-oidc
         env:
-          SEAL_DATA: |
-            {
-              "issuer": ${{ toJSON(secrets.OIDC_ISSUER) }},
-              "client-id": ${{ toJSON(secrets.OIDC_CLIENT_ID) }},
-              "client-secret": ${{ toJSON(secrets.OIDC_CLIENT_SECRET) }},
-              "group": ${{ toJSON(secrets.OIDC_GROUP) }}
-            }
+          OIDC_ISSUER: ${{ secrets.OIDC_ISSUER }}
+          OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+          OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
+          OIDC_GROUP: ${{ secrets.OIDC_GROUP }}
         run: |
           set -eu
-          WORKDIR="$(mktemp -d)"
-          trap 'rm -rf "$WORKDIR"' EXIT
-
           if ! command -v kubeseal >/dev/null 2>&1; then
-            curl -sfL -o "$WORKDIR/kubeseal.tar.gz" \
-              "https://github.com/bitnami/sealed-secrets/releases/download/v0.38.4/kubeseal-0.38.4-linux-amd64.tar.gz"
-            tar -xzf "$WORKDIR/kubeseal.tar.gz" -C "$WORKDIR" kubeseal
-            sudo install -m 0755 "$WORKDIR/kubeseal" /usr/local/bin/kubeseal
+            curl -sfL "https://github.com/bitnami/sealed-secrets/releases/download/v0.38.4/kubeseal-0.38.4-linux-amd64.tar.gz" \
+              | tar -xz -C /tmp kubeseal
+            sudo install -m 0755 /tmp/kubeseal /usr/local/bin/kubeseal
           fi
 
-          python3 - "$WORKDIR/plain.yaml" <<'PYEOF'
-          import base64, json, os, sys
-          data = json.loads(os.environ["SEAL_DATA"])
-          with open(sys.argv[1], "w") as f:
-              f.write("apiVersion: v1\nkind: Secret\nmetadata:\n")
-              f.write("  name: denpa-oidc\n  namespace: denpa\n")
-              f.write("type: Opaque\ndata:\n")
-              for key, value in data.items():
-                  b64 = base64.b64encode(value.encode()).decode()
-                  f.write(f"  {json.dumps(key)}: {b64}\n")
-          PYEOF
-
-          kubeseal --cert k3s/pub-cert.pem --format yaml \
-            < "$WORKDIR/plain.yaml" > k3s/oidc-sealed.yaml
+          kubectl create secret generic denpa-oidc \
+            --namespace denpa \
+            --from-literal=issuer="$OIDC_ISSUER" \
+            --from-literal=client-id="$OIDC_CLIENT_ID" \
+            --from-literal=client-secret="$OIDC_CLIENT_SECRET" \
+            --from-literal=group="$OIDC_GROUP" \
+            --dry-run=client -o yaml \
+          | kubeseal --cert k3s/pub-cert.pem --format yaml \
+          > k3s/oidc-sealed.yaml
 
       - name: Commit and push
         run: |


### PR DESCRIPTION
reseal-secrets.yml の Seal ステップを簡略化。

toJSON()でJSON化 → SEAL_DATA環境変数 → python heredocでbase64/YAML手組み、という流れを、`kubectl create secret generic --dry-run=client -o yaml | kubeseal` の1パイプラインに置き換え。

- `--dry-run=client` はk8s APIサーバーに一切接続しない（ローカルでオブジェクトを組み立てるだけ）ので、クラスタ非接続という既存の前提は変わらない
- mktemp/trap、pythonヒアドキュメント、手動base64エンコードが不要に
- Commit and push（PR作成）ステップは変更なし