### PR TITLE
fix: 観る画面で Ctrl+C が字幕の切り替えに取られ、コピーできなかった

### DIFF
--- a/src/routes/watch/[id]/+page.svelte
+++ b/src/routes/watch/[id]/+page.svelte
@@ -990,8 +990,16 @@
         return () => target.removeEventListener('click', press);
     });
 
-    /** キーでも動かせるようにする。全画面のときはこれがいちばん早い */
+    /**
+     * キーでも動かせるようにする。全画面のときはこれがいちばん早い。
+     *
+     * **修飾キー付きは取らない。** Ctrl+C (コピー) を `c` (字幕) として横取りして
+     * `preventDefault` していたので、観ながら番組名や URL を写せなかった。
+     * Ctrl+F (検索) → 全画面、Ctrl+S (保存) → 切り抜き、Cmd+K も同じ。
+     * Shift だけは通す (`<` `>` は Shift 込みで打つ)。IME 変換中のキーも渡さない
+     */
     function keys(event: KeyboardEvent): void {
+        if (event.altKey || event.ctrlKey || event.metaKey || event.isComposing) return;
         if ((event.target as HTMLElement).closest('input, button, a')) return;
         const map: Record<string, () => void> = {
             ' ': togglePlay,

--- a/tests/e2e/22-watch.spec.ts
+++ b/tests/e2e/22-watch.spec.ts
@@ -135,6 +135,30 @@ test.describe('録画を観る', () => {
     });
 
     /**
+     * **Ctrl+C は字幕の切り替えではなく、コピーのまま。** 観ながら番組名や
+     * URL を写せなかった (キーの `c` が修飾キーを見ずに横取りして
+     * `preventDefault` していた)。素の `c` だけが字幕を切り替えること
+     */
+    test('修飾キー付きのショートカットは横取りしない', async ({ page, request }) => {
+        test.setTimeout(180_000);
+        const id = await watchable(page, request);
+        await goto(page, `/watch/${id}`);
+
+        const button = page.getByTestId('watch-captions');
+        await expect(button).toHaveAttribute('aria-pressed', 'true');
+
+        // コピー (Ctrl / Cmd) は素通し。字幕は出たまま。**1回ずつ見る** (2回で元に戻ると見逃す)
+        await page.keyboard.press('Control+c');
+        await expect(button).toHaveAttribute('aria-pressed', 'true');
+        await page.keyboard.press('Meta+c');
+        await expect(button).toHaveAttribute('aria-pressed', 'true');
+
+        // 素の c は今までどおり字幕を切り替える
+        await page.keyboard.press('c');
+        await expect(button).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    /**
      * **切り抜きは字幕ごと。** 貼れるかどうか (クリップボード) は繋ぎ次第なので、
      * ここで見るのは「押せて、断られても落とすほうに倒れる」ところまで
      */


### PR DESCRIPTION
## なにを

録画を観る画面 (`/watch/<id>`) で、Ctrl+C / Cmd+C を押しても**コピーされず、字幕が出たり消えたりしていた**のを直します。

## なぜ

`keys` のショートカット (`c` 字幕・`f` 全画面・`s` 切り抜き・`k` 再生…) が **修飾キーを見ずに `event.key` だけで引いて `preventDefault`** していました。Ctrl+C の `event.key` は `c` なので、字幕の切り替えに取られてコピーが止まっていました。Ctrl+F (検索) → 全画面、Ctrl+S (保存) → 切り抜き、Cmd+K も同じです。

データ放送側 (`DataBroadcast.svelte` の `key`) は元から修飾キーを弾いていたので、それに揃えます。

## どう直したか

- `src/routes/watch/[id]/+page.svelte` — Alt / Ctrl / Meta 付きと IME 変換中 (`isComposing`) は素通し。**Shift は通したまま** (`<` `>` は Shift 込みで打つ)
- `tests/e2e/22-watch.spec.ts` — Ctrl+C / Cmd+C で字幕が動かず、素の `c` では動くことを見るテストを追加。修正を外すと落ちることを手元で確認済み

## 確かめたこと

- `bun run lint` / `bun run check` 通過
- `playwright test tests/e2e/22-watch.spec.ts -g "修飾キー|字幕の絵"` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QApfA9HGYKPFk3ohmPcGqo
