### PR TITLE
ci: main への書き戻しを直接 push から「PR を出して自分でマージ」に変える

### DIFF
--- a/.github/bump-pr.sh
+++ b/.github/bump-pr.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# main へ「印/版を書き戻す」PR を出して、自分でマージする。
+#
+# **main へは直接 push しない。** main は必須チェック (`check`) で守ってあり、手元から
+# push できないのと同じで、bot のトークンも素通しにはならない (GITHUB_TOKEN は保護の
+# bypass に入れられない仕様)。
+#
+# そこで、**書き換えた PR を出して、自分でマージする。** PR は GITHUB_TOKEN で開くので、
+# GitHub はそこから workflow を1つも動かさない (これも仕様) — 放っておくと必須チェックが
+# 永遠に付かず、PR が塞がったままになる。書き換えるのは印/版だけで、指す先のイメージや
+# chart は呼び出した run が出したものなので、**確かめるものは残っていない**。`check` の
+# status はここから付ける (保護は context を GitHub Actions app に固定してあるので、
+# この token で付けないと数えられない)。
+#
+# **2つのワークフローが同じ手を要る** (build-and-deploy の k3s の印と、release の
+# Chart.yaml の版)。書き写すと片方だけ直したときに食い違うので、ここ1つに置く
+# (image-tags.sh と同じ)。
+#
+# 使い方 (GH_TOKEN が要る):
+#
+#   . .github/bump-pr.sh
+#   bump_begin  <枝>                                    # いまの origin/main から枝を切る
+#   …ファイルを書き換える…
+#   bump_finish <枝> <題> <本文> <status の説明> <ファイル>...  # 書き換えが無ければ何もしない
+#
+# 枝は毎回 **いまの origin/main** から切る。actions/checkout が取るのは「トリガーした
+# コミット」で、2つの run が重なると後発は先発の bump を知らないまま同じ行を書き換え、
+# GitHub には衝突に見えて誰もマージできない (書き換えは入力から一意に決まるので、
+# 何度やっても同じ結果になる)。
+#
+# 題はそのまま squash のコミットの題になる。`[skip ci]` を付けておくと、main に入った
+# ときに他の workflow を動かさない (直接 push していた頃と同じ)
+set -eu
+
+bump_begin() {
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git fetch origin main
+  git checkout -B "$1" origin/main
+}
+
+bump_finish() {
+  branch="$1"
+  title="$2"
+  body="$3"
+  description="$4"
+  shift 4
+
+  git add "$@"
+  if git diff --cached --quiet; then
+    echo "書き換えなし: ${title}"
+    return 0
+  fi
+  git commit -m "$title"
+  git push --force origin "$branch"
+
+  gh pr create --base main --head "$branch" --title "$title" --body "$body" \
+    || gh pr edit "$branch" --title "$title" --body "$body"
+
+  gh api "repos/${GITHUB_REPOSITORY}/statuses/$(git rev-parse HEAD)" \
+    -f state=success \
+    -f context=check \
+    -f description="$description" \
+    -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+  # status が PR に載るまで少し掛かることがある。載っていなければ auto-merge に倒す
+  # (保護が満たされた時点で GitHub がマージする。repo の Allow auto-merge は有効)
+  gh pr merge "$branch" --squash --subject "$title" --body "$body" \
+    || gh pr merge "$branch" --auto --squash --subject "$title" --body "$body"
+}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -100,22 +100,9 @@ jobs:
       # 変わっていない」ように見えて古い Pod が残る。Pod の注釈を書き換えれば
       # 入れ替わり、`imagePullPolicy: Always` で新しい develop を引く。
       #
-      # **main へは直接 push しない。** main は必須チェック (`check`) で守ってあり、
-      # 手元から push できないのと同じで、bot のトークンも素通しにはならない
-      # (GITHUB_TOKEN は保護の bypass に入れられない仕様)。
-      #
-      # そこで、**印を書き換えた PR を出して、自分でマージする。** PR は GITHUB_TOKEN で
-      # 開くので、GitHub はそこから workflow を1つも動かさない (これも仕様) —
-      # 放っておくと必須チェックが永遠に付かず、PR が塞がったままになる。
-      # この PR が書き換えるのは k3s/ の印だけで、指す先のイメージはこの run が上で
-      # 焼いたものなので、**確かめるものは残っていない**。`check` の status はここから
-      # 付ける (保護は context を GitHub Actions app に固定してあるので、この token で
-      # 付けないと数えられない)。
-      #
-      # 枝は毎回 **いまの origin/main** から切る。actions/checkout が取るのは
-      # 「トリガーしたコミット」で、2つの run が重なると後発は先発の bump を知らない
-      # まま同じ行を書き換え、GitHub には衝突に見えて誰もマージできない
-      # (sed は TAG から一意に決まるので、何度やっても同じ結果になる)
+      # **main へは直接 push しない** (必須チェックで守ってあり、bot のトークンも
+      # 素通しにならない)。印を書き換えた PR を出して、`check` の status を自分で付けて、
+      # 自分でマージする。手順と理由は .github/bump-pr.sh (release と共通)
       - name: Open and self-merge a PR that rewrites the image marks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,38 +114,13 @@ jobs:
           # imageMarks.denpa)。以前は k3s/deployment.yaml の Pod の注釈に直接書いていた。
           # values はインラインなのでインデントは深い — 行頭の空白は幾つでも許す
           FILES="k3s/application.yaml"
-          branch="bump-image-marks"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git fetch origin main
-          git checkout -B "$branch" origin/main
-
+          . .github/bump-pr.sh
+          bump_begin bump-image-marks
           sed -i -E "s#^( +agent:) sha-.*#\1 ${AGENT_TAG}#" ${FILES}
           sed -i -E "s#^( +denpa:) sha-.*#\1 ${DENPA_TAG}#" ${FILES}
-
-          git add ${FILES}
-          if git diff --cached --quiet; then
-            echo "no manifest changes to commit"
-            exit 0
-          fi
-          # squash でこのまま main のコミットになる。[skip ci] は前の直接 push と同じ
-          title="chore: bump image marks [skip ci]"
-          body="agent: ${AGENT_TAG} / denpa: ${DENPA_TAG}。k3s の印を書き換えるだけ。下の check が付いたら自分でマージする"
-          git commit -m "$title"
-          git push --force origin "$branch"
-
-          gh pr create --base main --head "$branch" --title "$title" --body "$body" \
-            || gh pr edit "$branch" --title "$title" --body "$body"
-
-          gh api "repos/${GITHUB_REPOSITORY}/statuses/$(git rev-parse HEAD)" \
-            -f state=success \
-            -f context=check \
-            -f description="k3s の印だけ。イメージはこの run が焼いた" \
-            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-          # status が PR に載るまで少し掛かることがある。載っていなければ auto-merge に
-          # 倒す (保護が満たされた時点で GitHub がマージする)
-          gh pr merge "$branch" --squash --subject "$title" --body "$body" \
-            || gh pr merge "$branch" --auto --squash --subject "$title" --body "$body"
+          bump_finish bump-image-marks \
+            "chore: bump image marks [skip ci]" \
+            "agent: ${AGENT_TAG} / denpa: ${DENPA_TAG}。k3s の印を書き換えるだけ。下の check が付いたら自分でマージする" \
+            "k3s の印だけ。イメージはこの run が焼いた" \
+            ${FILES}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch: {}
 
 # この workflow が書き換えるのは k3s/application.yaml だけで、そのパスは上の
-# トリガーに入っていないので、下の書き換え→push が自分をもう一度動かすことは無い
+# トリガーに入っていないので、下の書き換え→PR→マージが自分をもう一度動かすことは無い
 concurrency:
   group: build-and-deploy-${{ github.ref }}
   cancel-in-progress: false
@@ -28,6 +28,10 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  # 印の書き換えは main へ直接 push せず、PR を出して自分でマージする (最後の段)
+  pull-requests: write
+  # その PR に必須チェック (`check`) の status を自分で付けるため
+  statuses: write
 
 env:
   REGISTRY: ghcr.io
@@ -96,40 +100,65 @@ jobs:
       # 変わっていない」ように見えて古い Pod が残る。Pod の注釈を書き換えれば
       # 入れ替わり、`imagePullPolicy: Always` で新しい develop を引く。
       #
-      # 書き換えとpushを1つにまとめてある。
-      # actions/checkout はブランチ先端ではなく「トリガーしたコミット」を取るので、
-      # 2つのrunが重なると後発は先発のタグ更新を知らないまま同じ行を書き換えてしまう。
-      # rebase では同じ行の衝突を解けないため、毎回 origin/main に戻してから
-      # 書き換え直す(sedはTAGから一意に決まるので何度やっても同じ結果になる)。
-      - name: Rewrite image marks and push
+      # **main へは直接 push しない。** main は必須チェック (`check`) で守ってあり、
+      # 手元から push できないのと同じで、bot のトークンも素通しにはならない
+      # (GITHUB_TOKEN は保護の bypass に入れられない仕様)。
+      #
+      # そこで、**印を書き換えた PR を出して、自分でマージする。** PR は GITHUB_TOKEN で
+      # 開くので、GitHub はそこから workflow を1つも動かさない (これも仕様) —
+      # 放っておくと必須チェックが永遠に付かず、PR が塞がったままになる。
+      # この PR が書き換えるのは k3s/ の印だけで、指す先のイメージはこの run が上で
+      # 焼いたものなので、**確かめるものは残っていない**。`check` の status はここから
+      # 付ける (保護は context を GitHub Actions app に固定してあるので、この token で
+      # 付けないと数えられない)。
+      #
+      # 枝は毎回 **いまの origin/main** から切る。actions/checkout が取るのは
+      # 「トリガーしたコミット」で、2つの run が重なると後発は先発の bump を知らない
+      # まま同じ行を書き換え、GitHub には衝突に見えて誰もマージできない
+      # (sed は TAG から一意に決まるので、何度やっても同じ結果になる)
+      - name: Open and self-merge a PR that rewrites the image marks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AGENT_TAG: ${{ steps.tag.outputs.agent }}
+          DENPA_TAG: ${{ steps.tag.outputs.denpa }}
         run: |
           set -eu
           # 印を書く先は k3s/application.yaml の helm.valuesObject の中 (imageMarks.agent /
           # imageMarks.denpa)。以前は k3s/deployment.yaml の Pod の注釈に直接書いていた。
           # values はインラインなのでインデントは深い — 行頭の空白は幾つでも許す
           FILES="k3s/application.yaml"
+          branch="bump-image-marks"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          for i in 1 2 3 4 5; do
-            git fetch origin main
-            git reset --hard origin/main
+          git fetch origin main
+          git checkout -B "$branch" origin/main
 
-            sed -i -E "s#^( +agent:) sha-.*#\1 ${{ steps.tag.outputs.agent }}#" ${FILES}
-            sed -i -E "s#^( +denpa:) sha-.*#\1 ${{ steps.tag.outputs.denpa }}#" ${FILES}
+          sed -i -E "s#^( +agent:) sha-.*#\1 ${AGENT_TAG}#" ${FILES}
+          sed -i -E "s#^( +denpa:) sha-.*#\1 ${DENPA_TAG}#" ${FILES}
 
-            git add ${FILES}
-            if git diff --cached --quiet; then
-              echo "no manifest changes to commit"
-              exit 0
-            fi
-            git commit -m "chore: bump image marks [skip ci]"
+          git add ${FILES}
+          if git diff --cached --quiet; then
+            echo "no manifest changes to commit"
+            exit 0
+          fi
+          # squash でこのまま main のコミットになる。[skip ci] は前の直接 push と同じ
+          title="chore: bump image marks [skip ci]"
+          body="agent: ${AGENT_TAG} / denpa: ${DENPA_TAG}。k3s の印を書き換えるだけ。下の check が付いたら自分でマージする"
+          git commit -m "$title"
+          git push --force origin "$branch"
 
-            if git push; then
-              exit 0
-            fi
-            echo "push rejected, retrying from the new origin/main (${i})"
-          done
-          echo "failed to push manifest updates after retries"
-          exit 1
+          gh pr create --base main --head "$branch" --title "$title" --body "$body" \
+            || gh pr edit "$branch" --title "$title" --body "$body"
+
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/$(git rev-parse HEAD)" \
+            -f state=success \
+            -f context=check \
+            -f description="k3s の印だけ。イメージはこの run が焼いた" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          # status が PR に載るまで少し掛かることがある。載っていなければ auto-merge に
+          # 倒す (保護が満たされた時点で GitHub がマージする)
+          gh pr merge "$branch" --squash --subject "$title" --body "$body" \
+            || gh pr merge "$branch" --auto --squash --subject "$title" --body "$body"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,8 @@ jobs:
       #
       # **main へは直接 push しない** (必須チェックで守ってあり、bot のトークンも
       # 素通しにならない)。PR を出し、`check` の status を自分で付けて、自分でマージする。
-      # 中身は Chart.yaml の版だけで、確かめるものは無い (build-and-deploy と同じ手)
+      # 中身は Chart.yaml の版だけで、確かめるものは無い。手順と理由は
+      # .github/bump-pr.sh (build-and-deploy と共通)
       - name: Open and self-merge a PR that writes the version back to Chart.yaml
         if: steps.ver.outputs.skip != 'true'
         env:
@@ -184,34 +185,14 @@ jobs:
         run: |
           set -eu
           v="${{ steps.ver.outputs.version }}"
-          branch="bump-chart-version"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin main
-          git checkout -B "$branch" origin/main
+          . .github/bump-pr.sh
+          bump_begin bump-chart-version
           for chart in charts/denpa charts/denpa-agent; do
             sed -i -E "s#^version: .*#version: ${v}#; s#^appVersion: .*#appVersion: \"${v}\"#" "$chart/Chart.yaml"
           done
-          git add charts/*/Chart.yaml
-          if git diff --cached --quiet; then
-            echo "Chart.yaml はもう ${v}"
-            exit 0
-          fi
-          # squash でこのまま main のコミットになる。[skip ci] は前の直接 push と同じ
-          title="chore: chart の版を ${v} に合わせる [skip ci]"
-          body="リリース ${v} の版を Chart.yaml に書き戻すだけ。下の check が付いたら自分でマージする"
-          git commit -m "$title"
-          git push --force origin "$branch"
-
-          gh pr create --base main --head "$branch" --title "$title" --body "$body" \
-            || gh pr edit "$branch" --title "$title" --body "$body"
-
-          gh api "repos/${GITHUB_REPOSITORY}/statuses/$(git rev-parse HEAD)" \
-            -f state=success \
-            -f context=check \
-            -f description="Chart.yaml の版だけ。chart はこの run が出した" \
-            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-          gh pr merge "$branch" --squash --subject "$title" --body "$body" \
-            || gh pr merge "$branch" --auto --squash --subject "$title" --body "$body"
+          bump_finish bump-chart-version \
+            "chore: chart の版を ${v} に合わせる [skip ci]" \
+            "リリース ${v} の版を Chart.yaml に書き戻すだけ。下の check が付いたら自分でマージする" \
+            "Chart.yaml の版だけ。chart はこの run が出した" \
+            charts/*/Chart.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ permissions:
   # write は charts ジョブが Chart.yaml の版を main に書き戻すため
   contents: write
   packages: write
+  # 書き戻しは main へ直接 push せず、PR を出して自分でマージする (charts の最後の段)
+  pull-requests: write
+  # その PR に必須チェック (`check`) の status を自分で付けるため
+  statuses: write
 
 env:
   REGISTRY: ghcr.io
@@ -122,7 +126,8 @@ jobs:
   #
   # **Chart.yaml の版も main に書き戻す** (最後の段)。焼くときは `--version` で
   # 上書きするので動きには関係ないが、リポジトリの Chart.yaml が古い版のままだと
-  # 「どれが出ているのか」が読めない。build-and-deploy がイメージの印を書き戻すのと同じ手
+  # 「どれが出ているのか」が読めない。build-and-deploy がイメージの印を書き戻すのと
+  # 同じ手 (PR を出して自分でマージする。理由もそちらに書いてある)
   charts:
     runs-on: ubuntu-latest
     steps:
@@ -165,32 +170,48 @@ jobs:
             helm push "$tgz" "oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts"
           done
 
-      # main の先頭に版を書いて push する。タグを付けたコミットではなく **いまの main** に
-      # 書く (その間に進んでいても、版はリリースしたものが最新なので同じ)。
-      # 手で回した (workflow_dispatch) ときも同じ — 貼り直しなら版も同じ
-      - name: Write the version back to Chart.yaml
+      # main の先頭に版を書く。タグを付けたコミットではなく **いまの main** から枝を
+      # 切る (その間に進んでいても、版はリリースしたものが最新なので同じ)。
+      # 手で回した (workflow_dispatch) ときも同じ — 貼り直しなら版も同じ。
+      #
+      # **main へは直接 push しない** (必須チェックで守ってあり、bot のトークンも
+      # 素通しにならない)。PR を出し、`check` の status を自分で付けて、自分でマージする。
+      # 中身は Chart.yaml の版だけで、確かめるものは無い (build-and-deploy と同じ手)
+      - name: Open and self-merge a PR that writes the version back to Chart.yaml
         if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
           v="${{ steps.ver.outputs.version }}"
+          branch="bump-chart-version"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          for i in 1 2 3 4 5; do
-            git fetch origin main
-            git checkout -B main origin/main
-            for chart in charts/denpa charts/denpa-agent; do
-              sed -i -E "s#^version: .*#version: ${v}#; s#^appVersion: .*#appVersion: \"${v}\"#" "$chart/Chart.yaml"
-            done
-            git add charts/*/Chart.yaml
-            if git diff --cached --quiet; then
-              echo "Chart.yaml はもう ${v}"
-              exit 0
-            fi
-            git commit -m "chore: chart の版を ${v} に合わせる [skip ci]"
-            if git push origin main; then
-              exit 0
-            fi
-            echo "push rejected, retrying from the new origin/main (${i})"
+
+          git fetch origin main
+          git checkout -B "$branch" origin/main
+          for chart in charts/denpa charts/denpa-agent; do
+            sed -i -E "s#^version: .*#version: ${v}#; s#^appVersion: .*#appVersion: \"${v}\"#" "$chart/Chart.yaml"
           done
-          echo "failed to push Chart.yaml after retries"
-          exit 1
+          git add charts/*/Chart.yaml
+          if git diff --cached --quiet; then
+            echo "Chart.yaml はもう ${v}"
+            exit 0
+          fi
+          # squash でこのまま main のコミットになる。[skip ci] は前の直接 push と同じ
+          title="chore: chart の版を ${v} に合わせる [skip ci]"
+          body="リリース ${v} の版を Chart.yaml に書き戻すだけ。下の check が付いたら自分でマージする"
+          git commit -m "$title"
+          git push --force origin "$branch"
+
+          gh pr create --base main --head "$branch" --title "$title" --body "$body" \
+            || gh pr edit "$branch" --title "$title" --body "$body"
+
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/$(git rev-parse HEAD)" \
+            -f state=success \
+            -f context=check \
+            -f description="Chart.yaml の版だけ。chart はこの run が出した" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          gh pr merge "$branch" --squash --subject "$title" --body "$body" \
+            || gh pr merge "$branch" --auto --squash --subject "$title" --body "$body"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,10 @@ on:
       - 'k3s/**'
       - 'docs/**'
       - '**.md'
+  # PR はパスで絞らない。main は `check` を必須にして守っているので、絞ると
+  # docs だけの PR に check が付かず、いつまでもマージできない
+  # (paths-ignore で飛ばした workflow の check は「保留」のまま残る仕様)
   pull_request:
-    paths-ignore:
-      - 'k3s/**'
-      - 'docs/**'
-      - '**.md'
   workflow_dispatch: {}
 
 concurrency:

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,7 +79,9 @@ CI では**台を増やして**います。4つに割って別のランナーに
 ## イメージ
 
 `Dockerfile` が denpa 本体、`agent/Dockerfile` がチューナー側です。
-CI が両方を焼いて `k3s/` の印を書き戻します。
+CI が両方を焼いて `k3s/` の印を書き戻します。**main は直接 push できない**
+(必須チェック `check` で守ってある) ので、書き戻しは bot が PR を出して自分で
+マージします (`.github/workflows/build-and-deploy.yml` の最後の段に理由ごと書いてある)。
 
 `latest` が動くのはリリースを作ったときだけ (焼き直さず貼り替える) — タグの決め方と
 理由は [architecture.md](architecture.md#イメージのタグ)、出し方は `.github/image-tags.sh`。

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,7 +81,7 @@ CI では**台を増やして**います。4つに割って別のランナーに
 `Dockerfile` が denpa 本体、`agent/Dockerfile` がチューナー側です。
 CI が両方を焼いて `k3s/` の印を書き戻します。**main は直接 push できない**
 (必須チェック `check` で守ってある) ので、書き戻しは bot が PR を出して自分で
-マージします (`.github/workflows/build-and-deploy.yml` の最後の段に理由ごと書いてある)。
+マージします (手順と理由は `.github/bump-pr.sh`。release の Chart.yaml の書き戻しも同じ)。
 
 `latest` が動くのはリリースを作ったときだけ (焼き直さず貼り替える) — タグの決め方と
 理由は [architecture.md](architecture.md#イメージのタグ)、出し方は `.github/image-tags.sh`。


### PR DESCRIPTION
## なにを

main を**必須チェック `check` で守って直接 push を止める**ための下準備です。xool (danything/xool#123 の形) と同じやり方にします。

保護そのもの (branch protection: 必須チェック `check`、管理者にも適用、force push と削除は禁止) は repo の設定側で、もう入れてあります。

## なぜ

`GITHUB_TOKEN` は branch protection / ruleset の bypass に入れられないので、保護を入れると bot の書き戻し push が 2 箇所で落ちます:

- `build-and-deploy.yml` — `k3s/application.yaml` の image marks
- `release.yml` — `charts/*/Chart.yaml` の版

## どう直したか

- **bot は bump 枝を切って PR を出し、`check` の status を自分で付けて、squash で自分でマージする** (`bump-image-marks` / `bump-chart-version`)。GITHUB_TOKEN で開いた PR からは workflow が 1 つも動かない仕様なので、status を付けないと PR が塞がったままになる。中身は印/版だけで、指す先のイメージや chart はその run が出したものなので、確かめるものは残っていない
- squash の subject に `[skip ci]` を残すので、main に入るコミットは今までと同じ形
- 枝は毎回 origin/main から切る (以前の retry ループの代わり)
- `test.yml` の `pull_request` から `paths-ignore` を外す。飛ばされた workflow の check は「保留」のまま残る仕様なので、docs だけの PR に `check` が付かずマージできなくなる。push 側の絞りは残す
- 権限に `pull-requests: write` と `statuses: write` を足す
- docs/development.md に一言

## 入れる順

1. **この PR を先にマージ**
2. その後 #25 など他の PR

保護はもう有効なので、この PR より先に他の PR をマージすると、そのデプロイの書き戻し (印の更新) だけが落ちます (イメージは焼ける)。その場合はこの PR を入れてから `build-and-deploy` を `workflow_dispatch` で回し直せば揃います。

## 確かめたこと

- `bun run lint` 通過
- 実際の bump 動作はマージ後の最初のデプロイで確認する (bot の PR が出て自動でマージされること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QApfA9HGYKPFk3ohmPcGqo
