### PR TITLE
test: エージェントのテストを TUnit に移行

### DIFF
--- a/agent/Denpa.Agent.Tests/ChannelTableTests.cs
+++ b/agent/Denpa.Agent.Tests/ChannelTableTests.cs
@@ -1,5 +1,5 @@
 using Denpa.Agent;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace Denpa.Agent.Tests;
 
@@ -14,136 +14,136 @@ namespace Denpa.Agent.Tests;
 
 public class ChannelTableTests
 {
-    [Fact]
-    public void 地上波は_Hz_で数える()
+    [Test]
+    public async Task 地上波は_Hz_で数える()
     {
         // UHF 13ch = 473.142857 MHz。1/7 MHz のずれは放送のとおりで、丸めない
-        Assert.Equal(473_142_857u, ChannelTable.Parse("T13")!.Frequency);
-        Assert.Equal(557_142_857u, ChannelTable.Parse("T27")!.Frequency);
-        Assert.Equal(767_142_857u, ChannelTable.Parse("T62")!.Frequency);
+        await Assert.That(ChannelTable.Parse("T13")!.Frequency).IsEqualTo(473_142_857u);
+        await Assert.That(ChannelTable.Parse("T27")!.Frequency).IsEqualTo(557_142_857u);
+        await Assert.That(ChannelTable.Parse("T62")!.Frequency).IsEqualTo(767_142_857u);
     }
 
-    [Fact]
-    public void 衛星は_kHz_で数える()
+    [Test]
+    public async Task 衛星は_kHz_で数える()
     {
         /*
          * DVB API の決まりで、**地上波は Hz、衛星は kHz**。取り違えても
          * ioctl は通るので、ここを間違えると「同期しない」としか見えない
          */
         var bs = ChannelTable.Parse("BS01_0")!;
-        Assert.Equal(ChannelTable.SysIsdbs, bs.Delivery);
-        Assert.Equal(1_049_480u, bs.Frequency);
+        await Assert.That(bs.Delivery).IsEqualTo(ChannelTable.SysIsdbs);
+        await Assert.That(bs.Frequency).IsEqualTo(1_049_480u);
 
         // 中継は 38.36 MHz 刻み。BS03 は BS01 の1つ隣
-        Assert.Equal(1_087_840u, ChannelTable.Parse("BS03_0")!.Frequency);
-        Assert.Equal(1_471_440u, ChannelTable.Parse("BS23_0")!.Frequency);
+        await Assert.That(ChannelTable.Parse("BS03_0")!.Frequency).IsEqualTo(1_087_840u);
+        await Assert.That(ChannelTable.Parse("BS23_0")!.Frequency).IsEqualTo(1_471_440u);
 
         // CS は 40 MHz 刻みで、BS とは別の並び
-        Assert.Equal(1_613_000u, ChannelTable.Parse("CS02")!.Frequency);
-        Assert.Equal(2_053_000u, ChannelTable.Parse("CS24")!.Frequency);
+        await Assert.That(ChannelTable.Parse("CS02")!.Frequency).IsEqualTo(1_613_000u);
+        await Assert.That(ChannelTable.Parse("CS24")!.Frequency).IsEqualTo(2_053_000u);
     }
 
-    [Fact]
-    public void 同じ周波数に相乗りしている本数を覚えておく()
+    [Test]
+    public async Task 同じ周波数に相乗りしている本数を覚えておく()
     {
         // BS01_0 と BS01_1 は**同じ周波数**。開いたままなら選局し直さずに済む
-        Assert.Equal(ChannelTable.Parse("BS01_0")!.Frequency, ChannelTable.Parse("BS01_3")!.Frequency);
-        Assert.Equal(0, ChannelTable.Parse("BS01_0")!.RelativeTs);
-        Assert.Equal(3, ChannelTable.Parse("BS01_3")!.RelativeTs);
+        await Assert.That(ChannelTable.Parse("BS01_3")!.Frequency).IsEqualTo(ChannelTable.Parse("BS01_0")!.Frequency);
+        await Assert.That(ChannelTable.Parse("BS01_0")!.RelativeTs).IsEqualTo(0);
+        await Assert.That(ChannelTable.Parse("BS01_3")!.RelativeTs).IsEqualTo(3);
     }
 
-    [Fact]
-    public void px4_の番号は別の数え方()
+    [Test]
+    public async Task px4_の番号は別の数え方()
     {
         // chardev は周波数ではなく表の番号で言う。地上波は物理チャンネル+50
-        Assert.Equal(68, ChannelTable.Parse("T18")!.FreqNo);
+        await Assert.That(ChannelTable.Parse("T18")!.FreqNo).IsEqualTo(68);
         // 衛星はスロットが相対TS番号そのもの
-        Assert.Equal((0, 2), (ChannelTable.Parse("BS01_2")!.FreqNo, ChannelTable.Parse("BS01_2")!.Slot));
-        Assert.Equal(11, ChannelTable.Parse("BS23_0")!.FreqNo);
-        Assert.Equal(12, ChannelTable.Parse("CS02")!.FreqNo);
-        Assert.Equal(23, ChannelTable.Parse("CS24")!.FreqNo);
+        await Assert.That((ChannelTable.Parse("BS01_2")!.FreqNo, ChannelTable.Parse("BS01_2")!.Slot)).IsEqualTo((0, 2));
+        await Assert.That(ChannelTable.Parse("BS23_0")!.FreqNo).IsEqualTo(11);
+        await Assert.That(ChannelTable.Parse("CS02")!.FreqNo).IsEqualTo(12);
+        await Assert.That(ChannelTable.Parse("CS24")!.FreqNo).IsEqualTo(23);
     }
 
-    [Fact]
-    public void ゼロ詰めは同じものとして読む()
+    [Test]
+    public async Task ゼロ詰めは同じものとして読む()
     {
-        Assert.Equal(ChannelTable.Parse("BS1_0")!.Frequency, ChannelTable.Parse("BS01_0")!.Frequency);
+        await Assert.That(ChannelTable.Parse("BS01_0")!.Frequency).IsEqualTo(ChannelTable.Parse("BS1_0")!.Frequency);
     }
 
-    [Theory]
-    [InlineData("T12")]      // UHF は 13 から
-    [InlineData("T63")]      // 62 まで
-    [InlineData("BS02_0")]   // BS は奇数だけ
-    [InlineData("BS25_0")]
-    [InlineData("BS19_8")]   // 相乗りは 8 本まで
-    [InlineData("CS01")]     // CS は偶数だけ
-    [InlineData("CS26")]
-    [InlineData("")]
-    [InlineData("T")]
-    [InlineData("SKY1")]
-    public void 受け取らない名前(string name)
+    [Test]
+    [Arguments("T12")]      // UHF は 13 から
+    [Arguments("T63")]      // 62 まで
+    [Arguments("BS02_0")]   // BS は奇数だけ
+    [Arguments("BS25_0")]
+    [Arguments("BS19_8")]   // 相乗りは 8 本まで
+    [Arguments("CS01")]     // CS は偶数だけ
+    [Arguments("CS26")]
+    [Arguments("")]
+    [Arguments("T")]
+    [Arguments("SKY1")]
+    public async Task 受け取らない名前(string name)
     {
-        Assert.Null(ChannelTable.Parse(name));
+        await Assert.That(ChannelTable.Parse(name)).IsNull();
     }
 
-    [Theory]
-    [InlineData("BS07_0")]
-    [InlineData("BS17_0")]
-    public void ISDB_S3_の中継は受け取らない(string name)
+    [Test]
+    [Arguments("BS07_0")]
+    [Arguments("BS17_0")]
+    public async Task ISDB_S3_の中継は受け取らない(string name)
     {
         // BS-7 と BS-17 は 4K/8K。この復調器では受からないので、総当たりの
         // スキャンでも試させない (実機に投げれば「同期しない」で5秒溶ける)
-        Assert.Null(ChannelTable.Parse(name));
+        await Assert.That(ChannelTable.Parse(name)).IsNull();
     }
 }
 
 public class StreamIdTests
 {
-    [Fact]
-    public void 地上波は選り分けない()
+    [Test]
+    public async Task 地上波は選り分けない()
     {
         var gr = ChannelTable.Parse("T27")!;
-        Assert.Equal(ChannelTable.NoStreamId, ChannelTable.StreamId("T27", gr, _ => 1234));
+        await Assert.That(ChannelTable.StreamId("T27", gr, _ => 1234)).IsEqualTo(ChannelTable.NoStreamId);
     }
 
-    [Fact]
-    public void CS_も選り分けない()
+    [Test]
+    public async Task CS_も選り分けない()
     {
         // 1つの中継に1本しか乗っていない
         var cs = ChannelTable.Parse("CS02")!;
-        Assert.Equal(ChannelTable.NoStreamId, ChannelTable.StreamId("CS02", cs, null));
+        await Assert.That(ChannelTable.StreamId("CS02", cs, null)).IsEqualTo(ChannelTable.NoStreamId);
     }
 
-    [Fact]
-    public void スキャン結果が焼き込んだ表に勝つ()
+    [Test]
+    public async Task スキャン結果が焼き込んだ表に勝つ()
     {
         // BS は再編がある。1度でもスキャンしていれば、そちらが必ず新しい
         var bs = ChannelTable.Parse("BS15_0")!;
-        Assert.Equal(16625u, ChannelTable.StreamId("BS15_0", bs, null));
-        Assert.Equal(9999u, ChannelTable.StreamId("BS15_0", bs, _ => 9999));
+        await Assert.That(ChannelTable.StreamId("BS15_0", bs, null)).IsEqualTo(16625u);
+        await Assert.That(ChannelTable.StreamId("BS15_0", bs, _ => 9999)).IsEqualTo(9999u);
     }
 
-    [Fact]
-    public void 表にも無ければ選り分けない()
+    [Test]
+    public async Task 表にも無ければ選り分けない()
     {
         // 焼き込んだ表に無い相乗り。TSID を指定せずに掴んで、あとは復調器任せ
         var bs = ChannelTable.Parse("BS15_7")!;
-        Assert.Equal(ChannelTable.NoStreamId, ChannelTable.StreamId("BS15_7", bs, _ => null));
+        await Assert.That(ChannelTable.StreamId("BS15_7", bs, _ => null)).IsEqualTo(ChannelTable.NoStreamId);
     }
 }
 
 public class DvbDeviceTests
 {
-    [Fact]
-    public void frontend_から_demux_と_dvr_を組み立てる()
+    [Test]
+    public async Task frontend_から_demux_と_dvr_を組み立てる()
     {
         var (adapter, number) = DvbTuner.Split("/dev/dvb/adapter1/frontend0");
 
-        Assert.Equal("/dev/dvb/adapter1", adapter);
-        Assert.Equal("0", number);
+        await Assert.That(adapter).IsEqualTo("/dev/dvb/adapter1");
+        await Assert.That(number).IsEqualTo("0");
     }
 
-    [Fact]
+    [Test]
     public void DVB_でないデバイスは受け取らない()
     {
         Assert.Throws<ArgumentException>(() => DvbTuner.Split("/dev/px4video0"));

--- a/agent/Denpa.Agent.Tests/ConfigTests.cs
+++ b/agent/Denpa.Agent.Tests/ConfigTests.cs
@@ -1,6 +1,8 @@
+using TUnit.Assertions.Enums;
+using System.IO;
 using System.Text.Json.Nodes;
 using Denpa.Agent;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace Denpa.Agent.Tests;
 
@@ -19,26 +21,26 @@ public class TunerSpecTests
             Path.Combine(work.FullName, "tuners.json"), Path.Combine(work.FullName, "channels.json"));
     }
 
-    [Fact]
-    public void 既定では外のコマンドを起こさない()
+    [Test]
+    public async Task 既定では外のコマンドを起こさない()
     {
         // 選局は自分でやる (ioctl)。`recisdb` はもう要らない
         var spec = new TunerSpec("adapter0", ["GR"], false, "/dev/dvb/adapter0/frontend0");
 
-        Assert.Null(spec.Resolve());
+        await Assert.That(spec.Resolve()).IsNull();
     }
 
-    [Fact]
-    public void 直に書いたコマンドが勝つ()
+    [Test]
+    public async Task 直に書いたコマンドが勝つ()
     {
         // 逃げ道。**画面からは触らせない** (ファイルに直に書いたときだけ効く)
         var spec = new TunerSpec("x", ["GR"], false, "/dev/null", null, "myTuner --ch {{channel}}");
 
-        Assert.Equal("myTuner --ch {{channel}}", spec.Resolve());
+        await Assert.That(spec.Resolve()).IsEqualTo("myTuner --ch {{channel}}");
     }
 
-    [Fact]
-    public void 書いて読み直すと同じものになる()
+    [Test]
+    public async Task 書いて読み直すと同じものになる()
     {
         var config = Fresh();
         config.SaveTuners([
@@ -47,41 +49,41 @@ public class TunerSpecTests
         ]);
 
         var read = config.LoadTuners();
-        Assert.Equal(2, read.Count);
-        Assert.Equal(["BS", "CS"], read[0].Types);
-        Assert.Equal("15v", read[0].Lnb);
-        Assert.Equal("/dev/dvb/adapter0/frontend0", read[0].Device);
-        Assert.True(read[1].Disabled);
+        await Assert.That(read.Count).IsEqualTo(2);
+        await Assert.That(read[0].Types).IsEquivalentTo(["BS", "CS"], CollectionOrdering.Matching);
+        await Assert.That(read[0].Lnb).IsEqualTo("15v");
+        await Assert.That(read[0].Device).IsEqualTo("/dev/dvb/adapter0/frontend0");
+        await Assert.That(read[1].Disabled).IsTrue();
     }
 
-    [Fact]
-    public void 空を渡すと定義を消す()
+    [Test]
+    public async Task 空を渡すと定義を消す()
     {
         // 「1本も無い」を書き込むより、**無い=自分で探す**のほうが後で困らない
         var config = Fresh();
         config.SaveTuners([new TunerSpec("a", ["GR"], false, "/dev/null")]);
-        Assert.True(File.Exists(config.TunersFile));
+        await Assert.That(File.Exists(config.TunersFile)).IsTrue();
 
         config.SaveTuners([]);
 
-        Assert.False(File.Exists(config.TunersFile));
-        Assert.Empty(config.LoadTuners());
+        await Assert.That(File.Exists(config.TunersFile)).IsFalse();
+        await Assert.That(config.LoadTuners()).IsEmpty();
     }
 
-    [Fact]
-    public void 壊れたファイルは空として扱う()
+    [Test]
+    public async Task 壊れたファイルは空として扱う()
     {
         // 起動できないよりは、画面に「チューナーがありません」と出したほうがいい
         var config = Fresh();
         File.WriteAllText(config.TunersFile, "{ これは JSON ではない");
 
-        Assert.Empty(config.LoadTuners());
+        await Assert.That(config.LoadTuners()).IsEmpty();
     }
 
-    [Fact]
-    public void 名前の無いものは受け取らない()
+    [Test]
+    public async Task 名前の無いものは受け取らない()
     {
-        Assert.Null(TunerSpec.FromJson(new JsonObject { ["types"] = new JsonArray() }));
+        await Assert.That(TunerSpec.FromJson(new JsonObject { ["types"] = new JsonArray() })).IsNull();
     }
 }
 
@@ -104,8 +106,8 @@ public class ChannelStoreTests
         return list;
     }
 
-    [Fact]
-    public void 探した種別だけ差し替える()
+    [Test]
+    public async Task 探した種別だけ差し替える()
     {
         // 地上波だけ探したときに全部を置き換えると BS と CS が設定から消える
         // (実際に消して、BS の予約が録れなくなった)
@@ -114,24 +116,22 @@ public class ChannelStoreTests
 
         var merged = config.SaveChannels(Entries(("GR", "T21")), ["GR"]);
 
-        Assert.Equal(["T21", "BS11_0"], merged.Select(entry => entry!["channel"]!.GetValue<string>()));
+        await Assert.That(merged.Select(entry => entry!["channel"]!.GetValue<string>())).IsEquivalentTo(["T21", "BS11_0"], CollectionOrdering.Matching);
     }
 
-    [Fact]
-    public void 種別ごとにまとめて並べる()
+    [Test]
+    public async Task 種別ごとにまとめて並べる()
     {
         var config = Fresh();
         var merged = config.SaveChannels(
             Entries(("CS", "CS02"), ("BS", "BS11_0"), ("GR", "T21"), ("GR", "T16"), ("BS", "BS03_0")),
             ["GR", "BS", "CS"]);
 
-        Assert.Equal(
-            ["T16", "T21", "BS03_0", "BS11_0", "CS02"],
-            merged.Select(entry => entry!["channel"]!.GetValue<string>()));
+        await Assert.That(merged.Select(entry => entry!["channel"]!.GetValue<string>())).IsEquivalentTo(["T16", "T21", "BS03_0", "BS11_0", "CS02"], CollectionOrdering.Matching);
     }
 
-    [Fact]
-    public void 局名は逃がさずそのまま書く()
+    [Test]
+    public async Task 局名は逃がさずそのまま書く()
     {
         /*
          * `channels.json` は人が開いて確かめるもの。既定の符号化器は非ASCIIを
@@ -146,37 +146,35 @@ public class ChannelStoreTests
         config.SaveChannels([entry], ["GR"]);
 
         var written = File.ReadAllText(config.ChannelsFile);
-        Assert.Contains("ＴＯＫＹＯ", written);
-        Assert.Contains("ＭＸ", written);
+        await Assert.That(written).Contains("ＴＯＫＹＯ");
+        await Assert.That(written).Contains("ＭＸ");
     }
 
-    [Fact]
-    public void まだ1度も預かっていなければ空()
+    [Test]
+    public async Task まだ1度も預かっていなければ空()
     {
-        Assert.Empty(Fresh().LoadChannels());
+        await Assert.That(Fresh().LoadChannels()).IsEmpty();
     }
 }
 
 public class RenderTests
 {
-    [Fact]
-    public void 選局コマンドのテンプレートを埋める()
+    [Test]
+    public async Task 選局コマンドのテンプレートを埋める()
     {
-        Assert.Equal(
-            "recisdb tune --device /dev/dvb/adapter0/frontend0 -c T27 -",
-            TunerPool.Render("recisdb tune --device /dev/dvb/adapter0/frontend0 -c {{{channel}}} -", "T27", "GR"));
+        await Assert.That(TunerPool.Render("recisdb tune --device /dev/dvb/adapter0/frontend0 -c {{{channel}}} -", "T27", "GR")).IsEqualTo("recisdb tune --device /dev/dvb/adapter0/frontend0 -c T27 -");
     }
 
-    [Fact]
-    public void 種別と長さも埋める()
+    [Test]
+    public async Task 種別と長さも埋める()
     {
-        Assert.Equal("x GR -", TunerPool.Render("x {{channel_type}} {{{duration}}}", "T27", "GR"));
+        await Assert.That(TunerPool.Render("x {{channel_type}} {{{duration}}}", "T27", "GR")).IsEqualTo("x GR -");
     }
 
-    [Fact]
-    public void 知らない差し込みは空にする()
+    [Test]
+    public async Task 知らない差し込みは空にする()
     {
-        Assert.Equal("a  b", TunerPool.Render("a {{{extra_args}}} b", "T27", "GR"));
+        await Assert.That(TunerPool.Render("a {{{extra_args}}} b", "T27", "GR")).IsEqualTo("a  b");
     }
 }
 
@@ -189,65 +187,65 @@ public class RenderTests
  */
 public class DeviceProbeTests
 {
-    [Fact]
-    public void 地上波と衛星を方式から分ける()
+    [Test]
+    public async Task 地上波と衛星を方式から分ける()
     {
         // 実機の PT3。adapter0/2 が ISDB-S(9)、adapter1/3 が ISDB-T(8)
-        Assert.Equal(["GR"], DeviceProbe.TypesFor([8]));
-        Assert.Equal(["BS", "CS"], DeviceProbe.TypesFor([9]));
+        await Assert.That(DeviceProbe.TypesFor([8])).IsEquivalentTo(["GR"], CollectionOrdering.Matching);
+        await Assert.That(DeviceProbe.TypesFor([9])).IsEquivalentTo(["BS", "CS"], CollectionOrdering.Matching);
         // 1本でどちらも受けられるものもある
-        Assert.Equal(["GR", "BS", "CS"], DeviceProbe.TypesFor([8, 9]));
+        await Assert.That(DeviceProbe.TypesFor([8, 9])).IsEquivalentTo(["GR", "BS", "CS"], CollectionOrdering.Matching);
     }
 
-    [Fact]
-    public void 知らない方式は種別にしない()
+    [Test]
+    public async Task 知らない方式は種別にしない()
     {
         // DVB-T や ATSC が出てきても、日本の放送には使わない
-        Assert.Empty(DeviceProbe.TypesFor([3, 11]));
+        await Assert.That(DeviceProbe.TypesFor([3, 11])).IsEmpty();
     }
 
-    [Fact]
-    public void frontend_info_から名前を読む()
+    [Test]
+    public async Task frontend_info_から名前を読む()
     {
         var info = new byte[168];
         System.Text.Encoding.UTF8.GetBytes("Toshiba TC90522 ISDB-S module").CopyTo(info, 0);
 
-        Assert.Equal("Toshiba TC90522 ISDB-S module", DeviceProbe.ParseName(info));
+        await Assert.That(DeviceProbe.ParseName(info)).IsEqualTo("Toshiba TC90522 ISDB-S module");
     }
 
-    [Fact]
-    public void 方式を答えないドライバは名前で当てる()
+    [Test]
+    public async Task 方式を答えないドライバは名前で当てる()
     {
-        Assert.Equal(["BS", "CS"], DeviceProbe.TypesFromName("Toshiba TC90522 ISDB-S module"));
-        Assert.Equal(["GR"], DeviceProbe.TypesFromName("Toshiba TC90522 ISDB-T module"));
+        await Assert.That(DeviceProbe.TypesFromName("Toshiba TC90522 ISDB-S module")).IsEquivalentTo(["BS", "CS"], CollectionOrdering.Matching);
+        await Assert.That(DeviceProbe.TypesFromName("Toshiba TC90522 ISDB-T module")).IsEquivalentTo(["GR"], CollectionOrdering.Matching);
         // 名前に方式が入っていないものは当てにいかない (黙って間違えるより出さない)
-        Assert.Empty(DeviceProbe.TypesFromName("Some Generic Frontend"));
+        await Assert.That(DeviceProbe.TypesFromName("Some Generic Frontend")).IsEmpty();
     }
 
-    [Fact]
-    public void dtv_property_から方式の並びを取り出す()
+    [Test]
+    public async Task dtv_property_から方式の並びを取り出す()
     {
         var property = new byte[76];
         BitConverter.TryWriteBytes(property.AsSpan(48), 2u);  // u.buffer.len
         property[16] = 8;                                     // u.buffer.data[0] = ISDB-T
         property[17] = 9;                                     // u.buffer.data[1] = ISDB-S
 
-        Assert.Equal([8, 9], DeviceProbe.ParseDelivery(property));
+        await Assert.That(DeviceProbe.ParseDelivery(property)).IsEquivalentTo([8, 9], CollectionOrdering.Matching);
     }
 
-    [Fact]
-    public void 何も入っていなければ空()
+    [Test]
+    public async Task 何も入っていなければ空()
     {
-        Assert.Empty(DeviceProbe.ParseDelivery(new byte[76]));
+        await Assert.That(DeviceProbe.ParseDelivery(new byte[76])).IsEmpty();
     }
 
-    [Fact]
-    public void chardev_は名前の決まりで分ける()
+    [Test]
+    public async Task chardev_は名前の決まりで分ける()
     {
         // px4_drv は方式を聞ける口を持たない。番号の決まりがそのまま種別
-        Assert.Equal(["BS", "CS"], DeviceProbe.TypesForChardev("px4video0"));
-        Assert.Equal(["GR"], DeviceProbe.TypesForChardev("px4video2"));
-        Assert.Equal(["GR", "BS", "CS"], DeviceProbe.TypesForChardev("pxmlt5video0"));
-        Assert.Empty(DeviceProbe.TypesForChardev("sda"));
+        await Assert.That(DeviceProbe.TypesForChardev("px4video0")).IsEquivalentTo(["BS", "CS"], CollectionOrdering.Matching);
+        await Assert.That(DeviceProbe.TypesForChardev("px4video2")).IsEquivalentTo(["GR"], CollectionOrdering.Matching);
+        await Assert.That(DeviceProbe.TypesForChardev("pxmlt5video0")).IsEquivalentTo(["GR", "BS", "CS"], CollectionOrdering.Matching);
+        await Assert.That(DeviceProbe.TypesForChardev("sda")).IsEmpty();
     }
 }

--- a/agent/Denpa.Agent.Tests/Denpa.Agent.Tests.csproj
+++ b/agent/Denpa.Agent.Tests/Denpa.Agent.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- xunit.v3 のテストは自分で実行できるアプリ。前は Microsoft.NET.Test.Sdk が
-             暗黙にやっていたが、外したので明示する (無いとビルドが断る) -->
+        <!-- TUnit のテストは自分で実行できるアプリ (Microsoft.Testing.Platform)。
+             Microsoft.NET.Test.Sdk は持たない (TUnit の検出を壊す) -->
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
@@ -29,8 +29,9 @@
     <ItemGroup>
         <!-- MTP (global.json の test.runner) で回すので、旧 VSTest 系
              (Microsoft.NET.Test.Sdk / xunit.runner.visualstudio) は持たない。
-             xunit.v3 だけで MTP のテストアプリとして完結する -->
-        <PackageReference Include="xunit.v3" Version="4.0.0" />
+             TUnit だけで MTP のテストアプリとして完結する。TUnit はソース
+             ジェネレータで動くので、本体と同じく Native AOT でも通る -->
+        <PackageReference Include="TUnit" Version="1.65.68" />
     </ItemGroup>
 
 </Project>

--- a/agent/Denpa.Agent.Tests/DeviceStreamTests.cs
+++ b/agent/Denpa.Agent.Tests/DeviceStreamTests.cs
@@ -66,13 +66,13 @@ public partial class DeviceStreamTests
             var buffer = new byte[188];
             var reading = Task.Run(() => stream.Read(buffer, 0, buffer.Length, () => false));
 
-            var waited = await Task.WhenAny(reading, Task.Delay(TimeSpan.FromMilliseconds(600), CancellationToken.None));
+            var waited = await Task.WhenAny(reading, Task.Delay(TimeSpan.FromMilliseconds(600), TestContext.Current!.Execution.CancellationToken));
             await Assert.That(waited).IsNotSameReferenceAs(reading);
 
             // 書けば返ってくる
             var payload = new byte[] { 0x47, 0x01, 0x02 };
             await Assert.That(Write(write, payload)).IsEqualTo(payload.Length);
-            await Assert.That(await reading.WaitAsync(TimeSpan.FromSeconds(2), CancellationToken.None)).IsEqualTo(payload.Length);
+            await Assert.That(await reading.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current!.Execution.CancellationToken)).IsEqualTo(payload.Length);
         }
     }
 

--- a/agent/Denpa.Agent.Tests/DeviceStreamTests.cs
+++ b/agent/Denpa.Agent.Tests/DeviceStreamTests.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Denpa.Agent;
 using Microsoft.Win32.SafeHandles;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace Denpa.Agent.Tests;
 
@@ -26,13 +26,14 @@ public partial class DeviceStreamTests
     private static (DeviceStream Stream, SafeFileHandle Write) Silent()
     {
         Span<int> fds = stackalloc int[2];
-        Assert.Equal(0, Pipe(fds));
+        // Assert は await が要るので、stackalloc を跨げないここでは素直に投げる
+        if (Pipe(fds) != 0) throw new InvalidOperationException("pipe() に失敗");
         return (new DeviceStream(new SafeFileHandle(fds[0], ownsHandle: true)),
             new SafeFileHandle(fds[1], ownsHandle: true));
     }
 
-    [Fact]
-    public void 降りると言えば_何も来なくても戻る()
+    [Test]
+    public async Task 降りると言えば_何も来なくても戻る()
     {
         var (stream, write) = Silent();
         using (stream)
@@ -44,8 +45,8 @@ public partial class DeviceStreamTests
             var read = stream.Read(buffer, 0, buffer.Length, () => true);
             clock.Stop();
 
-            Assert.Equal(0, read);
-            Assert.True(clock.ElapsedMilliseconds < 1000, $"{clock.ElapsedMilliseconds}ms 掛かった");
+            await Assert.That(read).IsEqualTo(0);
+            await Assert.That(clock.ElapsedMilliseconds < 1000).IsTrue().Because($"{clock.ElapsedMilliseconds}ms 掛かった");
         }
     }
 
@@ -55,7 +56,7 @@ public partial class DeviceStreamTests
      * 何も来ないからといって勝手に終わると、電波が一瞬途切れただけで録画が
      * 落ちることになる。実際に来ていないだけなら待ち続けるのが正しい
      */
-    [Fact]
+    [Test]
     public async Task 降りると言わなければ_来るまで待つ()
     {
         var (stream, write) = Silent();
@@ -65,13 +66,13 @@ public partial class DeviceStreamTests
             var buffer = new byte[188];
             var reading = Task.Run(() => stream.Read(buffer, 0, buffer.Length, () => false));
 
-            var waited = await Task.WhenAny(reading, Task.Delay(TimeSpan.FromMilliseconds(600), TestContext.Current.CancellationToken));
-            Assert.NotSame(reading, waited);
+            var waited = await Task.WhenAny(reading, Task.Delay(TimeSpan.FromMilliseconds(600), CancellationToken.None));
+            await Assert.That(waited).IsNotSameReferenceAs(reading);
 
             // 書けば返ってくる
             var payload = new byte[] { 0x47, 0x01, 0x02 };
-            Assert.Equal(payload.Length, Write(write, payload));
-            Assert.Equal(payload.Length, await reading.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+            await Assert.That(Write(write, payload)).IsEqualTo(payload.Length);
+            await Assert.That(await reading.WaitAsync(TimeSpan.FromSeconds(2), CancellationToken.None)).IsEqualTo(payload.Length);
         }
     }
 

--- a/agent/Denpa.Agent.Tests/LeaseReadersTests.cs
+++ b/agent/Denpa.Agent.Tests/LeaseReadersTests.cs
@@ -1,5 +1,5 @@
 using Denpa.Agent;
-using Xunit;
+using System.Threading.Tasks;
 
 namespace Denpa.Agent.Tests;
 
@@ -16,47 +16,47 @@ public class LeaseReadersTests
 {
     private static Lease Make() => new(0, "GR", "T27");
 
-    [Fact]
-    public void 誰も来ていなければ読み手なし()
+    [Test]
+    public async Task 誰も来ていなければ読み手なし()
     {
-        Assert.Equal("読み手なし", Make().Readers());
+        await Assert.That(Make().Readers()).IsEqualTo("読み手なし");
     }
 
-    [Fact]
-    public void 抜けたあとでも名乗る()
+    [Test]
+    public async Task 抜けたあとでも名乗る()
     {
         var lease = Make();
         lease.Saw("live GR/T27");
         // 読み手はもう居ない (Sinks は空のまま) が、居たことは残っている
-        Assert.Equal("live GR/T27", lease.Readers());
+        await Assert.That(lease.Readers()).IsEqualTo("live GR/T27");
     }
 
-    [Fact]
-    public void 読んだら忘れる()
+    [Test]
+    public async Task 読んだら忘れる()
     {
         var lease = Make();
         lease.Saw("epg T27");
-        Assert.Equal("epg T27", lease.Readers());
+        await Assert.That(lease.Readers()).IsEqualTo("epg T27");
         // 次の報告まで誰も来なければ、そこは本当に読み手なし
-        Assert.Equal("読み手なし", lease.Readers());
+        await Assert.That(lease.Readers()).IsEqualTo("読み手なし");
     }
 
-    [Fact]
-    public void 相乗りは並べる()
+    [Test]
+    public async Task 相乗りは並べる()
     {
         var lease = Make();
         lease.Saw("logo GR/T27");
         lease.Saw("epg T27");
         // 並びは決まった順にする。回すたびに入れ替わると差分が読めない
-        Assert.Equal("epg T27・logo GR/T27", lease.Readers());
+        await Assert.That(lease.Readers()).IsEqualTo("epg T27・logo GR/T27");
     }
 
-    [Fact]
-    public void 同じ読み手は一度だけ()
+    [Test]
+    public async Task 同じ読み手は一度だけ()
     {
         var lease = Make();
         lease.Saw("live GR/T27");
         lease.Saw("live GR/T27");
-        Assert.Equal("live GR/T27", lease.Readers());
+        await Assert.That(lease.Readers()).IsEqualTo("live GR/T27");
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-    "//": "dotnet test を Microsoft.Testing.Platform (MTP) の口で動かす。.NET 10 SDK は旧来の VSTest 経路で MTP のテスト (xunit.v3) を回せなくなった — これが無いと `Testing with VSTest target is no longer supported` で agent のテストが落ちる",
+    "//": "dotnet test を Microsoft.Testing.Platform (MTP) の口で動かす。.NET 10 SDK は旧来の VSTest 経路で MTP のテスト (TUnit) を回せなくなった — これが無いと `Testing with VSTest target is no longer supported` で agent のテストが落ちる",
     "test": {
         "runner": "Microsoft.Testing.Platform"
     }


### PR DESCRIPTION
.NET のテストは TUnit に統一する方針に合わせ、\`agent/Denpa.Agent.Tests\` を xunit.v3 4.0.0 から TUnit 1.65.68 に移行しました。

- TUnit は Microsoft.Testing.Platform ネイティブなので、\`global.json\` の \`test.runner\` も CI の \`dotnet test --project\` もそのまま
- 書き換えは TUnit 同梱のフィクサー(\`dotnet format analyzers --diagnostics TUXU0001\`)で実施
- 手で直した箇所: コレクション比較(\`IsEquivalentTo(..., CollectionOrdering.Matching)\`)、\`stackalloc\` を跨げない \`Silent()\` の pipe() 判定、\`TestContext.Current.CancellationToken\`
- 手元で \`dotnet test --project agent/Denpa.Agent.Tests/Denpa.Agent.Tests.csproj\`: 50 件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Skgu5kDGLhfUUChrVtePfp