### PR TITLE
refactor: 残りの生 SQL を drizzle の型付きクエリに置き換える

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -96,6 +96,20 @@ export function orm() {
     return typed;
 }
 
+/**
+ * 変えた行数が要るときの `.run()`。
+ *
+ * bun の `.run()` は行数を返しているのに、drizzle の型の上では void になる。
+ * 1行なら `.returning()` で足りるが、まとめて消す/直すところで全行を返させるのは
+ * 無駄なので、組み立てた SQL を生の接続で流して行数を取る
+ */
+export function affected(query: { toSQL(): { sql: string; params: unknown[] } }): number {
+    const { sql, params } = query.toSQL();
+    return database()
+        .query(sql)
+        .run(...(params as SQLQueryBindings[])).changes;
+}
+
 export function now(): number {
     return Date.now();
 }

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -101,7 +101,10 @@ export function orm() {
  *
  * bun の `.run()` は行数を返しているのに、drizzle の型の上では void になる。
  * 1行なら `.returning()` で足りるが、まとめて消す/直すところで全行を返させるのは
- * 無駄なので、組み立てた SQL を生の接続で流して行数を取る
+ * 無駄なので、組み立てた SQL を生の接続で流して行数を取る。
+ *
+ * 接続は `orm()` と同じ1本なので、drizzle のトランザクションの中から呼んでも
+ * その中で流れる (epg.ts の syncServices → clearBelongings がそれ)
  */
 export function affected(query: { toSQL(): { sql: string; params: unknown[] } }): number {
     const { sql, params } = query.toSQL();

--- a/src/lib/server/encoder.ts
+++ b/src/lib/server/encoder.ts
@@ -12,6 +12,7 @@ import {
     writeFileSync,
 } from 'node:fs';
 import { basename, dirname } from 'node:path';
+import { and, eq, getTableColumns, inArray, ne, or, sql } from 'drizzle-orm';
 import { type Audio, audioTitles, DUAL_MONO } from '$lib/arib';
 import { HW_KIND_LABEL, type HwCodec } from '../hw';
 import { encodeSource } from '../source';
@@ -30,13 +31,14 @@ import {
     widenKeep,
 } from './cm';
 import { config } from './config';
-import { database, now, queryOne } from './db';
+import { affected, now, orm } from './db';
 import { type EncodeProgress, emit } from './events';
 import { removeByPrefix, removeIfExists } from './fsx';
 import { type HwWay, hwArgs, hwChain } from './hwenc';
 import { encodedPath, libraryFamily, libraryPath } from './library';
 import { removeSidecars, sidecarPaths, writeThumbnail } from './metadata';
 import { saveRecordedBml } from './recorded-bml';
+import { encodeJobs, recordings, services } from './schema';
 import { descramble, isScrambled } from './scramble';
 import { settings } from './settings';
 import { chunks, run } from './stream';
@@ -557,20 +559,24 @@ export function concatList(parts: string[]): string {
 
 /** その録画で今生きているジョブ (待ち・実行中) の id。無ければ undefined */
 export function activeEncodeJob(recordingId: number): number | undefined {
-    return queryOne<{ id: number }>(
-        `SELECT id FROM encode_jobs WHERE recording_id = ? AND state IN ('queued', 'running')`,
-        recordingId,
-    )?.id;
+    return orm()
+        .select({ id: encodeJobs.id })
+        .from(encodeJobs)
+        .where(
+            and(eq(encodeJobs.recording_id, recordingId), inArray(encodeJobs.state, ['queued', 'running'])),
+        )
+        .get()?.id;
 }
 
 export function enqueue(recordingId: number): number {
     const existing = activeEncodeJob(recordingId);
     if (existing !== undefined) return existing;
 
-    const info = database()
-        .prepare(`INSERT INTO encode_jobs (recording_id, state, created_at) VALUES (?, 'queued', ?)`)
-        .run(recordingId, now());
-    return Number(info.lastInsertRowid);
+    return orm()
+        .insert(encodeJobs)
+        .values({ recording_id: recordingId, state: 'queued', created_at: now() })
+        .returning({ id: encodeJobs.id })
+        .get()!.id;
 }
 
 export function cancel(jobId: number): void {
@@ -579,20 +585,23 @@ export function cancel(jobId: number): void {
     aborts.get(jobId)?.abort();
     procs.get(jobId)?.kill();
 
-    const stopped = database()
-        .prepare(
-            `UPDATE encode_jobs SET state = 'canceled', finished_at = ? WHERE id = ? AND state = 'queued'`,
-        )
-        .run(now(), jobId);
+    const stopped = orm()
+        .update(encodeJobs)
+        .set({ state: 'canceled', finished_at: now() })
+        .where(and(eq(encodeJobs.id, jobId), eq(encodeJobs.state, 'queued')))
+        .returning({ id: encodeJobs.id })
+        .get();
     // まだ始まっていなければここで終わり。走っている分は runJob が後始末して知らせる
-    if (stopped.changes > 0) emit('recordings');
+    if (stopped !== undefined) emit('recordings');
 }
 
 /** 段階を進めて画面にも伝える。押しても反応が無いように見えるのを防ぐ */
 function setPhase(jobId: number, phase: EncodePhase, log: string): void {
-    database()
-        .prepare('UPDATE encode_jobs SET phase = ?, log = ?, percent = 0, eta_ms = NULL WHERE id = ?')
-        .run(phase, log, jobId);
+    orm()
+        .update(encodeJobs)
+        .set({ phase, log, percent: 0, eta_ms: null })
+        .where(eq(encodeJobs.id, jobId))
+        .run();
     emit('recordings');
 }
 
@@ -603,7 +612,7 @@ function setPhase(jobId: number, phase: EncodePhase, log: string): void {
  * (「CM検出中」) だけでは、進んでいるのか止まっているのかが分からなかった。
  */
 function setStep(jobId: number, log: string): void {
-    database().prepare('UPDATE encode_jobs SET log = ? WHERE id = ?').run(log, jobId);
+    orm().update(encodeJobs).set({ log }).where(eq(encodeJobs.id, jobId)).run();
     emit('recordings');
 }
 
@@ -614,13 +623,16 @@ function setStep(jobId: number, log: string): void {
  * 画面のほうも追いつかない。
  */
 function progressReporter(jobId: number): (percent: number) => void {
-    const update = database().prepare('UPDATE encode_jobs SET percent = ? WHERE id = ?');
     let lastWrite = 0;
     return (percent) => {
         const at = Date.now();
         if (at - lastWrite < PROGRESS_INTERVAL) return;
         lastWrite = at;
-        update.run(Math.min(1, Math.max(0, percent)), jobId);
+        orm()
+            .update(encodeJobs)
+            .set({ percent: Math.min(1, Math.max(0, percent)) })
+            .where(eq(encodeJobs.id, jobId))
+            .run();
         emit('recordings');
     };
 }
@@ -779,9 +791,8 @@ async function runFfmpeg(
     let lastWrite = 0;
     let stderrTail = '';
 
-    const updateProgress = database().prepare(
-        'UPDATE encode_jobs SET percent = ?, eta_ms = ?, log = ? WHERE id = ?',
-    );
+    const updateProgress = (percent: number, etaMs: number | null, log: string) =>
+        orm().update(encodeJobs).set({ percent, eta_ms: etaMs, log }).where(eq(encodeJobs.id, job.id)).run();
 
     const readStderr = (async () => {
         const decoder = new TextDecoder();
@@ -824,7 +835,7 @@ async function runFfmpeg(
                 const wroteAt = Date.now();
                 if (wroteAt - lastWrite >= PROGRESS_INTERVAL) {
                     lastWrite = wroteAt;
-                    updateProgress.run(percent, etaMs, log, job.id);
+                    updateProgress(percent, etaMs, log);
                     /*
                      * 進み具合は**中身ごと**流す (`encode` イベント)。`recordings` で
                      * 流していた頃は、数秒おきに一覧がページ全体を読み直していて、
@@ -844,7 +855,7 @@ async function runFfmpeg(
 
     const [code] = await Promise.all([proc.exited, readStdout, readStderr]);
     procs.delete(job.id);
-    updateProgress.run(code === 0 ? 1 : percent, null, log, job.id);
+    updateProgress(code === 0 ? 1 : percent, null, log);
     return { code, stderrTail: failureReason(stderrTail), outTimeUs };
 }
 
@@ -897,10 +908,11 @@ async function prepareCm(
          * ロゴの位置を手で入れてもらっていれば渡す。自動で見つからない局
          * (薄い・動くロゴ) はこれが無いとロゴ無しの判定に落ちる
          */
-        const service = queryOne<{ logo_area: string | null }>(
-            'SELECT logo_area FROM services WHERE id = ?',
-            recording.service_id,
-        );
+        const service = orm()
+            .select({ logo_area: services.logo_area })
+            .from(services)
+            .where(eq(services.id, recording.service_id))
+            .get();
         detection = await detectCm(input, {
             signal,
             channel: recording.service_name,
@@ -919,12 +931,16 @@ async function prepareCm(
      * 持っていた頃は、後から「位置を教える口を出す条件」を広げても、既に録ってある
      * 分には効かなかった
      */
-    database()
-        .prepare('UPDATE recordings SET cm_ranges = ?, cm_note = ?, updated_at = ? WHERE id = ?')
-        .run(JSON.stringify(detection.cm), detection.note, now(), recording.id);
-    database()
-        .prepare('UPDATE encode_jobs SET log = ? WHERE id = ?')
-        .run(`CM ${detection.cm.length} 箇所 (${detection.note})`, jobId);
+    orm()
+        .update(recordings)
+        .set({ cm_ranges: JSON.stringify(detection.cm), cm_note: detection.note, updated_at: now() })
+        .where(eq(recordings.id, recording.id))
+        .run();
+    orm()
+        .update(encodeJobs)
+        .set({ log: `CM ${detection.cm.length} 箇所 (${detection.note})` })
+        .where(eq(encodeJobs.id, jobId))
+        .run();
     if (detection.cm.length === 0) return none;
 
     if (settings().cmCut === 'cut') {
@@ -1034,9 +1050,11 @@ function clearScratch(input: string): void {
 
 /** ジョブを失敗にする (行を書くだけ。知らせも画面の更新もしない) */
 function markFailed(jobId: number, reason: string): void {
-    database()
-        .prepare(`UPDATE encode_jobs SET state = 'failed', error = ?, finished_at = ? WHERE id = ?`)
-        .run(reason, now(), jobId);
+    orm()
+        .update(encodeJobs)
+        .set({ state: 'failed', error: reason, finished_at: now() })
+        .where(eq(encodeJobs.id, jobId))
+        .run();
 }
 
 /**
@@ -1071,9 +1089,11 @@ function fail(jobId: number, recording: Recording, reason: string): void {
  */
 function finishCanceled(jobId: number, working: string | null): void {
     removeIfExists(working);
-    database()
-        .prepare(`UPDATE encode_jobs SET state = 'canceled', finished_at = ? WHERE id = ?`)
-        .run(now(), jobId);
+    orm()
+        .update(encodeJobs)
+        .set({ state: 'canceled', finished_at: now() })
+        .where(eq(encodeJobs.id, jobId))
+        .run();
     // 録画の行は触らない。ジョブが消えれば「録画済み」に戻って見える
     emit('recordings');
 }
@@ -1083,8 +1103,8 @@ async function runJob(jobId: number): Promise<void> {
     aborts.set(jobId, controller);
     const signal = controller.signal;
 
-    const job = queryOne<EncodeJob>('SELECT * FROM encode_jobs WHERE id = ?', jobId)!;
-    const recording = queryOne<Recording>('SELECT * FROM recordings WHERE id = ?', job.recording_id);
+    const job = orm().select().from(encodeJobs).where(eq(encodeJobs.id, jobId)).get()!;
+    const recording = orm().select().from(recordings).where(eq(recordings.id, job.recording_id)).get();
     const input = recording === undefined ? null : encodeSource(recording);
 
     if (recording === undefined || input === null) {
@@ -1256,9 +1276,11 @@ async function runJob(jobId: number): Promise<void> {
     }
 
     if (pgs !== null) {
-        database()
-            .prepare('UPDATE encode_jobs SET log = ? WHERE id = ?')
-            .run(`字幕 ${pgs.captions} 枚を PGS にしました`, jobId);
+        orm()
+            .update(encodeJobs)
+            .set({ log: `字幕 ${pgs.captions} 枚を PGS にしました` })
+            .where(eq(encodeJobs.id, jobId))
+            .run();
     }
 
     if (canceled.has(jobId)) {
@@ -1295,12 +1317,16 @@ async function runJob(jobId: number): Promise<void> {
     if (recording.alt_path !== null) stalePaths.add(recording.alt_path);
     for (const candidate of libraryFamily(recording)) {
         if (stalePaths.has(candidate) || !existsSync(candidate)) continue;
-        const claimed = queryOne<{ id: number }>(
-            'SELECT id FROM recordings WHERE (library_path = ? OR alt_path = ?) AND id != ?',
-            candidate,
-            candidate,
-            recording.id,
-        );
+        const claimed = orm()
+            .select({ id: recordings.id })
+            .from(recordings)
+            .where(
+                and(
+                    or(eq(recordings.library_path, candidate), eq(recordings.alt_path, candidate)),
+                    ne(recordings.id, recording.id),
+                ),
+            )
+            .get();
         if (claimed === undefined) stalePaths.add(candidate);
     }
     if (stalePaths.size > 0) {
@@ -1308,11 +1334,11 @@ async function runJob(jobId: number): Promise<void> {
             removeIfExists(stalePath);
             removeSidecars(stalePath);
         }
-        database()
-            .prepare(
-                'UPDATE recordings SET library_path = NULL, alt_path = NULL, updated_at = ? WHERE id = ?',
-            )
-            .run(now(), recording.id);
+        orm()
+            .update(recordings)
+            .set({ library_path: null, alt_path: null, updated_at: now() })
+            .where(eq(recordings.id, recording.id))
+            .run();
         emit('recordings');
     }
 
@@ -1384,9 +1410,11 @@ async function runJob(jobId: number): Promise<void> {
                 // 数えるのは頭を捨てる再試行だけ (毒ジョブの見立て `encodeMaxAttempts` の物差し)。
                 // GPU から降りるのは、その素材ではその道が使えないというだけで、毒ではない
                 if (attempt.seek !== null) {
-                    database()
-                        .prepare('UPDATE encode_jobs SET attempts = attempts + 1 WHERE id = ?')
-                        .run(jobId);
+                    orm()
+                        .update(encodeJobs)
+                        .set({ attempts: sql`${encodeJobs.attempts} + 1` })
+                        .where(eq(encodeJobs.id, jobId))
+                        .run();
                 }
                 const before = attempts[i - 1].hardware;
                 if (attempt.hardware !== before) {
@@ -1485,9 +1513,11 @@ async function runJob(jobId: number): Promise<void> {
     const made = (await probeVideo(output)).duration;
     const length = Number.isFinite(made) ? made * 1000 : lastOutTimeUs / 1000;
     if (Number.isFinite(length) && length > 0) {
-        database()
-            .prepare('UPDATE recordings SET duration_ms = ? WHERE id = ?')
-            .run(Math.round(length), recording.id);
+        orm()
+            .update(recordings)
+            .set({ duration_ms: Math.round(length) })
+            .where(eq(recordings.id, recording.id))
+            .run();
     }
 
     // サムネイルを動画の隣に書く。動画を置いた直後に作る。
@@ -1507,9 +1537,11 @@ async function runJob(jobId: number): Promise<void> {
         if (existsSync(primaryPoster)) copyFileSync(primaryPoster, sidecarPaths(alt).thumbnail);
     }
 
-    database()
-        .prepare(`UPDATE encode_jobs SET state = 'done', percent = 1, finished_at = ? WHERE id = ?`)
-        .run(now(), jobId);
+    orm()
+        .update(encodeJobs)
+        .set({ state: 'done', percent: 1, finished_at: now() })
+        .where(eq(encodeJobs.id, jobId))
+        .run();
     emit('recordings');
     notify({
         event: 'encode.finished',
@@ -1527,28 +1559,29 @@ async function runJob(jobId: number): Promise<void> {
     // 主は AV1 (`output`)、もう一方は `alt` (両方焼いたときだけ)。
     // コマ数 (実測か既定の60) も一緒に書く — 番組詳細の札はここからしか出せない
     const fps = encodeOptions.smoothMotion === true ? 60 : 30;
+    const finished = { library_path: output, alt_path: alt, ts_size: size, fps, updated_at: now() };
     if (settings().keepOriginal) {
-        database()
-            .prepare(
-                `UPDATE recordings SET library_path = ?, alt_path = ?, ts_size = ?, fps = ?, updated_at = ? WHERE id = ?`,
-            )
-            .run(output, alt, size, fps, now(), recording.id);
+        orm().update(recordings).set(finished).where(eq(recordings.id, recording.id)).run();
     } else {
         removeIfExists(recording.ts_path);
-        database()
-            .prepare(
-                `UPDATE recordings SET library_path = ?, alt_path = ?, ts_path = NULL, ts_size = ?, fps = ?, updated_at = ? WHERE id = ?`,
-            )
-            .run(output, alt, size, fps, now(), recording.id);
+        orm()
+            .update(recordings)
+            .set({ ...finished, ts_path: null })
+            .where(eq(recordings.id, recording.id))
+            .run();
     }
 }
 
 /** 同時実行数の空きぶんだけキューを消化する。録画完了時と定期tickの両方から呼ばれる */
 export function pump(): void {
     while (runningJobs.size < config.encodeConcurrency) {
-        const next = queryOne<{ id: number; attempts: number }>(
-            `SELECT id, attempts FROM encode_jobs WHERE state = 'queued' ORDER BY id LIMIT 1`,
-        );
+        const next = orm()
+            .select({ id: encodeJobs.id, attempts: encodeJobs.attempts })
+            .from(encodeJobs)
+            .where(eq(encodeJobs.state, 'queued'))
+            .orderBy(encodeJobs.id)
+            .limit(1)
+            .get();
         if (next === undefined) return;
 
         // **試し過ぎたジョブは諦める。** プロセスごと落とす毒ジョブは running→queued
@@ -1556,10 +1589,12 @@ export function pump(): void {
         // して後ろを進める。failed の確定は runJob を呼ぶ前なので、直後にまた落ちても
         // 同じジョブを掴み直すことはない
         if (next.attempts >= config.encodeMaxAttempts) {
-            const recording = queryOne<Recording>(
-                'SELECT r.* FROM recordings r JOIN encode_jobs j ON j.recording_id = r.id WHERE j.id = ?',
-                next.id,
-            );
+            const recording = orm()
+                .select(getTableColumns(recordings))
+                .from(recordings)
+                .innerJoin(encodeJobs, eq(encodeJobs.recording_id, recordings.id))
+                .where(eq(encodeJobs.id, next.id))
+                .get();
             const reason = `エンコードを ${next.attempts} 回試して完了しませんでした`;
             if (recording === undefined) {
                 markFailed(next.id, reason);
@@ -1574,13 +1609,13 @@ export function pump(): void {
         }
 
         // 実際に走り出す前に状態を進めておく。次のループが同じジョブを拾わないため
-        const claimed = database()
-            .prepare(
-                `UPDATE encode_jobs SET state = 'running', started_at = ?, attempts = attempts + 1
-                 WHERE id = ? AND state = 'queued'`,
-            )
-            .run(now(), next.id);
-        if (claimed.changes === 0) return;
+        const claimed = orm()
+            .update(encodeJobs)
+            .set({ state: 'running', started_at: now(), attempts: sql`${encodeJobs.attempts} + 1` })
+            .where(and(eq(encodeJobs.id, next.id), eq(encodeJobs.state, 'queued')))
+            .returning({ id: encodeJobs.id })
+            .get();
+        if (claimed === undefined) return;
 
         const jobId = next.id;
         runningJobs.add(jobId);
@@ -1605,10 +1640,10 @@ export function pump(): void {
  * ffmpeg は親と一緒に死んでいるので、出力を捨てて頭からやり直す。
  */
 export function requeueOrphanedJobs(): number {
-    return database()
-        .prepare(
-            `UPDATE encode_jobs SET state = 'queued', phase = 'encode', percent = 0, eta_ms = NULL,
-                    started_at = NULL WHERE state = 'running'`,
-        )
-        .run().changes;
+    return affected(
+        orm()
+            .update(encodeJobs)
+            .set({ state: 'queued', phase: 'encode', percent: 0, eta_ms: null, started_at: null })
+            .where(eq(encodeJobs.state, 'running')),
+    );
 }

--- a/src/lib/server/epg.ts
+++ b/src/lib/server/epg.ts
@@ -1,10 +1,11 @@
+import { and, count, eq, gt, inArray, isNull, lt, ne, sql } from 'drizzle-orm';
 import type { EitEvent } from '../ts/eit';
-import type { Service } from '../types';
 import { config } from './config';
-import { database, now, queryAll, queryOne } from './db';
+import { affected, database, now, orm } from './db';
 import { emit } from './events';
 import { applyRules } from './rules';
 import { resolveConflicts } from './scheduler';
+import { programs, reservations, services } from './schema';
 import { toHalfWidth } from './title';
 import { type AgentChannel, getChannels, programKey, serviceKey } from './tuner';
 
@@ -75,20 +76,6 @@ export function airing<S extends { id: number }, P extends { service_id: number;
 }
 
 export function syncServices(channels: AgentChannel[]): number {
-    const stmt = database().prepare(`
-        INSERT INTO services (id, service_id, network_id, name, type, service_type, channel,
-                              remote_control_key, has_logo, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(id) DO UPDATE SET
-            service_id = excluded.service_id,
-            network_id = excluded.network_id,
-            name = excluded.name,
-            type = excluded.type,
-            service_type = excluded.service_type,
-            channel = excluded.channel,
-            remote_control_key = excluded.remote_control_key,
-            updated_at = excluded.updated_at
-    `);
     const at = now();
     let count = 0;
     const dropped: number[] = [];
@@ -98,7 +85,8 @@ export function syncServices(channels: AgentChannel[]): number {
      * なっていた (時計の刻みが1msしかない)
      */
     const seen = new Set<number>();
-    const tx = database().transaction(() => {
+    let canceled = 0;
+    orm().transaction((tx) => {
         for (const channel of channels) {
             for (const service of channel.services) {
                 const id = serviceKey(channel.networkId, service.serviceId);
@@ -108,19 +96,34 @@ export function syncServices(channels: AgentChannel[]): number {
                     continue;
                 }
                 seen.add(id);
-                stmt.run(
-                    id,
-                    service.serviceId,
-                    channel.networkId,
-                    toHalfWidth(service.name),
-                    channel.type,
-                    service.serviceType,
-                    channel.channel,
-                    channel.remoteControlKeyId,
-                    // ロゴは放送波から拾ったときに立てる (logo.ts)
-                    0,
-                    at,
-                );
+                tx.insert(services)
+                    .values({
+                        id,
+                        service_id: service.serviceId,
+                        network_id: channel.networkId,
+                        name: toHalfWidth(service.name),
+                        type: channel.type,
+                        service_type: service.serviceType,
+                        channel: channel.channel,
+                        remote_control_key: channel.remoteControlKeyId,
+                        // ロゴは放送波から拾ったときに立てる (logo.ts)
+                        has_logo: 0,
+                        updated_at: at,
+                    })
+                    .onConflictDoUpdate({
+                        target: services.id,
+                        set: {
+                            service_id: sql`excluded.service_id`,
+                            network_id: sql`excluded.network_id`,
+                            name: sql`excluded.name`,
+                            type: sql`excluded.type`,
+                            service_type: sql`excluded.service_type`,
+                            channel: sql`excluded.channel`,
+                            remote_control_key: sql`excluded.remote_control_key`,
+                            updated_at: sql`excluded.updated_at`,
+                        },
+                    })
+                    .run();
                 count++;
             }
         }
@@ -134,13 +137,11 @@ export function syncServices(channels: AgentChannel[]): number {
          */
         for (const id of dropped) {
             clearBelongings(at, id);
-            database().prepare('DELETE FROM services WHERE id = ?').run(id);
+            tx.delete(services).where(eq(services.id, id)).run();
         }
         // この回で見かけなかった局の持ち物を片付ける
         if (count > 0) canceled = forgetMissing(at, seen);
     });
-    let canceled = 0;
-    tx();
     // 取り消した予約は一覧に出ている。同じものを見ている端末が食い違わないように
     if (canceled > 0) emit('reservations');
     return count;
@@ -157,15 +158,21 @@ export function syncServices(channels: AgentChannel[]): number {
  * (消すと、その局で録った録画や過去の予約が辿れなくなる)。
  */
 function clearBelongings(at: number, serviceId: number): { programs: number; reservations: number } {
-    const reservations = database()
-        .prepare(
-            // 録り始めたものは触らない。取り消しても録画は戻らない
-            `UPDATE reservations SET state = 'canceled', updated_at = ?
-             WHERE service_id = ? AND state IN ('scheduled', 'conflict') AND started_at IS NULL`,
-        )
-        .run(at, serviceId).changes;
-    const programs = database().prepare('DELETE FROM programs WHERE service_id = ?').run(serviceId).changes;
-    return { programs, reservations };
+    const canceled = affected(
+        orm()
+            .update(reservations)
+            .set({ state: 'canceled', updated_at: at })
+            .where(
+                and(
+                    eq(reservations.service_id, serviceId),
+                    inArray(reservations.state, ['scheduled', 'conflict']),
+                    // 録り始めたものは触らない。取り消しても録画は戻らない
+                    isNull(reservations.started_at),
+                ),
+            ),
+    );
+    const removed = affected(orm().delete(programs).where(eq(programs.service_id, serviceId)));
+    return { programs: removed, reservations: canceled };
 }
 
 /**
@@ -192,9 +199,11 @@ function clearBelongings(at: number, serviceId: number): { programs: number; res
  * エージェントが一時的に転んだだけなら、戻ってきた時点で時計が巻き戻る。
  */
 function forgetMissing(at: number, seen: Set<number>): number {
-    const stale = queryAll<{ id: number; name: string; updated_at: number }>(
-        'SELECT id, name, updated_at FROM services',
-    ).filter((service) => !seen.has(service.id) && at - service.updated_at >= config.serviceForgetAfter);
+    const stale = orm()
+        .select({ id: services.id, name: services.name, updated_at: services.updated_at })
+        .from(services)
+        .all()
+        .filter((service) => !seen.has(service.id) && at - service.updated_at >= config.serviceForgetAfter);
     if (stale.length === 0) return 0;
 
     let programs = 0;
@@ -222,15 +231,16 @@ function forgetMissing(at: number, seen: Set<number>): number {
  * 番組表が空のまま何も出ない時間が続く。
  */
 export async function syncServicesOnly(): Promise<number> {
-    const current = `SELECT COUNT(*) AS n FROM services WHERE ${CURRENT_SERVICES}`;
-    const before = queryOne<{ n: number }>(current)?.n ?? 0;
-    const count = syncServices(await getChannels());
+    const current = () =>
+        orm().select({ n: count() }).from(services).where(sql.raw(CURRENT_SERVICES)).get()?.n ?? 0;
+    const before = current();
+    const synced = syncServices(await getChannels());
     /*
      * 数が変わったときだけ知らせる。毎回知らせると、番組表を開いている端末が
      * 何も変わっていないのに1分おきに読み直すことになる
      */
-    if ((queryOne<{ n: number }>(current)?.n ?? 0) !== before) emit('services');
-    return count;
+    if (current() !== before) emit('services');
+    return synced;
 }
 
 /**
@@ -241,41 +251,43 @@ export async function syncServicesOnly(): Promise<number> {
  * 番組が丸ごと出なくなる。networkId と合わせて引き直す。
  */
 function serviceIdIndex(): Map<string, number> {
-    const services = queryAll<Service>('SELECT id, network_id, service_id FROM services');
-    return new Map(services.map((s) => [`${s.network_id}:${s.service_id}`, s.id]));
+    const rows = orm()
+        .select({ id: services.id, network_id: services.network_id, service_id: services.service_id })
+        .from(services)
+        .all();
+    return new Map(rows.map((s) => [`${s.network_id}:${s.service_id}`, s.id]));
 }
 
 /** 読み取った番組をDBへ。取り込めた件数を返す */
 export function savePrograms(events: EitEvent[]): number {
     const index = serviceIdIndex();
-    const stmt = database().prepare(`
-        INSERT INTO programs (id, service_id, network_id, event_id, start_at, end_at,
-                              name, description, extended, genres, genre_detail,
-                              is_free, audio_type, audios, video_type, video_resolution, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(id) DO UPDATE SET
-            -- service_id も上書きする。ここを更新しないと、一度おかしな値で入った行が
-            -- 取り込み直しても直らない(番組表が空のままになる)
-            service_id = excluded.service_id,
-            network_id = excluded.network_id,
-            start_at = excluded.start_at,
-            end_at = excluded.end_at,
-            -- 空で塗り潰さない。番組表は「基本」(題名) と「詳細」(番組内容) の
-            -- 2つの表に分かれて流れてきて、片方しか読めなかった回がある
-            -- (ts/eit.ts の EpgReader.merge)。読めたところだけ書く
-            name = CASE WHEN excluded.name = '' THEN programs.name ELSE excluded.name END,
-            description = CASE WHEN excluded.description = ''
-                          THEN programs.description ELSE excluded.description END,
-            extended = COALESCE(excluded.extended, programs.extended),
-            genres = excluded.genres,
-            genre_detail = excluded.genre_detail,
-            is_free = excluded.is_free,
-            audio_type = excluded.audio_type,
-            audios = excluded.audios,
-            video_type = excluded.video_type,
-            video_resolution = excluded.video_resolution,
-            updated_at = excluded.updated_at
-    `);
+    /**
+     * 同じ番組が来たら上書きする中身。
+     *
+     * service_id も上書きする。ここを更新しないと、一度おかしな値で入った行が
+     * 取り込み直しても直らない (番組表が空のままになる)。
+     *
+     * **題名と概要は空で塗り潰さない。** 番組表は「基本」(題名) と「詳細」(番組内容) の
+     * 2つの表に分かれて流れてきて、片方しか読めなかった回がある
+     * (ts/eit.ts の EpgReader.merge)。読めたところだけ書く
+     */
+    const refresh = {
+        service_id: sql`excluded.service_id`,
+        network_id: sql`excluded.network_id`,
+        start_at: sql`excluded.start_at`,
+        end_at: sql`excluded.end_at`,
+        name: sql`CASE WHEN excluded.name = '' THEN ${programs.name} ELSE excluded.name END`,
+        description: sql`CASE WHEN excluded.description = '' THEN ${programs.description} ELSE excluded.description END`,
+        extended: sql`COALESCE(excluded.extended, ${programs.extended})`,
+        genres: sql`excluded.genres`,
+        genre_detail: sql`excluded.genre_detail`,
+        is_free: sql`excluded.is_free`,
+        audio_type: sql`excluded.audio_type`,
+        audios: sql`excluded.audios`,
+        video_type: sql`excluded.video_type`,
+        video_resolution: sql`excluded.video_resolution`,
+        updated_at: sql`excluded.updated_at`,
+    };
     /*
      * **同じ局で時間が重なった行は、あとから来たほうが勝つ。**
      *
@@ -286,13 +298,9 @@ export function savePrograms(events: EitEvent[]): number {
      * 受信機の流儀に合わせて、重なった古い行はここで消す (送り直しが来れば
      * event_id ごと戻ってくる)
      */
-    const sweep = database().prepare(`
-        DELETE FROM programs
-        WHERE service_id = ? AND id != ? AND start_at < ? AND end_at > ?
-    `);
     const at = now();
     let count = 0;
-    const tx = database().transaction(() => {
+    orm().transaction((tx) => {
         for (const event of events) {
             // 開始も尺も決まっていないものは録画の時刻が決まらない
             if (event.startAt === null || event.duration === null || event.duration === 0) continue;
@@ -301,44 +309,57 @@ export function savePrograms(events: EitEvent[]): number {
             if (serviceId === undefined) continue;
             const extended = Object.keys(event.extended).length === 0 ? null : event.extended;
             const key = programKey(event.originalNetworkId, event.serviceId, event.eventId);
-            sweep.run(serviceId, key, event.startAt + event.duration, event.startAt);
-            stmt.run(
-                key,
-                serviceId,
-                event.originalNetworkId,
-                event.eventId,
-                event.startAt,
-                event.startAt + event.duration,
-                toHalfWidth(event.name),
-                toHalfWidth(event.description),
-                extended === null ? null : JSON.stringify(extended),
-                event.genres.length === 0 ? null : JSON.stringify(event.genres.map((g) => g.lv1)),
-                event.genres.length === 0 ? null : JSON.stringify(event.genres),
-                event.isFree ? 1 : 0,
-                event.audios[0]?.componentType ?? null,
-                event.audios.length === 0
-                    ? null
-                    : JSON.stringify(
-                          /*
-                           * **放送が付けた名前も残す。** 解説放送や二重音声は、
-                           * 種別も言語も同じ音声が2本並ぶので、符号だけでは
-                           * 「ステレオ (日本語)」が2つになって見分けが付かない
-                           */
-                          event.audios.map((a) => ({
-                              componentType: a.componentType,
-                              langs: a.langs,
-                              ...(a.text === undefined ? {} : { text: a.text }),
-                              ...(a.main === undefined ? {} : { main: a.main }),
-                          })),
-                      ),
-                event.video?.type ?? null,
-                event.video?.resolution ?? null,
-                at,
-            );
+            const endAt = event.startAt + event.duration;
+            tx.delete(programs)
+                .where(
+                    and(
+                        eq(programs.service_id, serviceId),
+                        ne(programs.id, key),
+                        lt(programs.start_at, endAt),
+                        gt(programs.end_at, event.startAt),
+                    ),
+                )
+                .run();
+            tx.insert(programs)
+                .values({
+                    id: key,
+                    service_id: serviceId,
+                    network_id: event.originalNetworkId,
+                    event_id: event.eventId,
+                    start_at: event.startAt,
+                    end_at: endAt,
+                    name: toHalfWidth(event.name),
+                    description: toHalfWidth(event.description),
+                    extended: extended === null ? null : JSON.stringify(extended),
+                    genres: event.genres.length === 0 ? null : JSON.stringify(event.genres.map((g) => g.lv1)),
+                    genre_detail: event.genres.length === 0 ? null : JSON.stringify(event.genres),
+                    is_free: event.isFree ? 1 : 0,
+                    audio_type: event.audios[0]?.componentType ?? null,
+                    audios:
+                        event.audios.length === 0
+                            ? null
+                            : JSON.stringify(
+                                  /*
+                                   * **放送が付けた名前も残す。** 解説放送や二重音声は、
+                                   * 種別も言語も同じ音声が2本並ぶので、符号だけでは
+                                   * 「ステレオ (日本語)」が2つになって見分けが付かない
+                                   */
+                                  event.audios.map((a) => ({
+                                      componentType: a.componentType,
+                                      langs: a.langs,
+                                      ...(a.text === undefined ? {} : { text: a.text }),
+                                      ...(a.main === undefined ? {} : { main: a.main }),
+                                  })),
+                              ),
+                    video_type: event.video?.type ?? null,
+                    video_resolution: event.video?.resolution ?? null,
+                    updated_at: at,
+                })
+                .onConflictDoUpdate({ target: programs.id, set: refresh })
+                .run();
             count++;
         }
     });
-    tx();
     return count;
 }
 
@@ -373,7 +394,7 @@ function syncReservationTimes(): number {
 /** 終わった番組を消す。番組表は未来しか見ないので、直近の分だけ残せば足りる */
 function pruneOldPrograms(): number {
     const cutoff = now() - config.programRetention;
-    return database().prepare('DELETE FROM programs WHERE end_at < ?').run(cutoff).changes;
+    return affected(orm().delete(programs).where(lt(programs.end_at, cutoff)));
 }
 
 export interface SyncResult {

--- a/src/lib/server/files.ts
+++ b/src/lib/server/files.ts
@@ -1,10 +1,12 @@
 import { type Dirent, existsSync, readdirSync, rmdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { and, eq, inArray, isNotNull, isNull, lt, max, notInArray, or, sql } from 'drizzle-orm';
 import type { Recording } from '../types';
 import { config } from './config';
-import { database, now, queryAll } from './db';
+import { affected, now, orm } from './db';
 import { pruneEmptyDirs, removeIfExists } from './fsx';
 import { removeSidecars, SIDECAR_SUFFIXES } from './metadata';
+import { encodeJobs, recordings, reservations } from './schema';
 
 const SIDECAR_ORPHAN = new RegExp(
     `^(.+?)(?:${SIDECAR_SUFFIXES.map((suffix) => suffix.replace(/[.-]/g, '\\$&')).join('|')})$`,
@@ -30,12 +32,18 @@ export function deleteRecordingFiles(recording: Recording, reason: string): void
     removeIfExists(recording.ts_path);
     // 失敗した録画を消したときに理由を上書きすると、なぜ失敗したのかが分からなくなる。
     // 元の理由があるならそちらを残す
-    database()
-        .prepare(
-            `UPDATE recordings SET deleted_at = ?, library_path = NULL, alt_path = NULL, ts_path = NULL,
-             error = COALESCE(NULLIF(error, ''), ?), updated_at = ? WHERE id = ?`,
-        )
-        .run(now(), reason, now(), recording.id);
+    orm()
+        .update(recordings)
+        .set({
+            deleted_at: now(),
+            library_path: null,
+            alt_path: null,
+            ts_path: null,
+            error: sql`COALESCE(NULLIF(${recordings.error}, ''), ${reason})`,
+            updated_at: now(),
+        })
+        .where(eq(recordings.id, recording.id))
+        .run();
 }
 
 /**
@@ -56,17 +64,21 @@ export function reconcile(): {
     strays: number;
     pruned: number;
 } {
-    const recordings = queryAll<Recording>(
-        `SELECT * FROM recordings WHERE library_path IS NOT NULL AND deleted_at IS NULL`,
-    );
+    const placed = orm()
+        .select()
+        .from(recordings)
+        .where(and(isNotNull(recordings.library_path), isNull(recordings.deleted_at)))
+        .all();
 
     let removed = 0;
-    for (const recording of recordings) {
+    for (const recording of placed) {
         // もう一方 (H.264) だけが外から消えたら、その控えだけ外す。主は無事なので録画は残る
         if (recording.alt_path !== null && !existsSync(recording.alt_path)) {
-            database()
-                .prepare('UPDATE recordings SET alt_path = NULL, updated_at = ? WHERE id = ?')
-                .run(now(), recording.id);
+            orm()
+                .update(recordings)
+                .set({ alt_path: null, updated_at: now() })
+                .where(eq(recordings.id, recording.id))
+                .run();
             removeSidecars(recording.alt_path);
             console.log(`[files] もう一方が消えていたので控えを外しました: ${recording.name}`);
         }
@@ -77,11 +89,11 @@ export function reconcile(): {
          * 消してしまわないため。もう一方も無ければ、いつもどおり削除済みに倒す
          */
         if (recording.alt_path !== null && existsSync(recording.alt_path)) {
-            database()
-                .prepare(
-                    'UPDATE recordings SET library_path = ?, alt_path = NULL, updated_at = ? WHERE id = ?',
-                )
-                .run(recording.alt_path, now(), recording.id);
+            orm()
+                .update(recordings)
+                .set({ library_path: recording.alt_path, alt_path: null, updated_at: now() })
+                .where(eq(recordings.id, recording.id))
+                .run();
             console.log(`[files] 主が消えたので繰り上げました: ${recording.name}`);
             continue;
         }
@@ -91,7 +103,7 @@ export function reconcile(): {
     }
 
     const left = sweepLeftovers();
-    return { checked: recordings.length, removed, ...left };
+    return { checked: placed.length, removed, ...left };
 }
 
 /** 動画そのもの。これに付き添うものが「付き添い」 */
@@ -137,11 +149,16 @@ function settling(path: string, at: number): boolean {
  */
 function sweepLeftovers(): { swept: number; strays: number; pruned: number } {
     const known = new Set(
-        queryAll<{ path: string | null }>(
-            `SELECT ts_path AS path FROM recordings WHERE ts_path IS NOT NULL
-             UNION SELECT library_path FROM recordings WHERE library_path IS NOT NULL
-             UNION SELECT alt_path FROM recordings WHERE alt_path IS NOT NULL`,
-        ).map((row) => row.path as string),
+        orm()
+            .select({
+                ts_path: recordings.ts_path,
+                library_path: recordings.library_path,
+                alt_path: recordings.alt_path,
+            })
+            .from(recordings)
+            .all()
+            .flatMap((row) => [row.ts_path, row.library_path, row.alt_path])
+            .filter((path): path is string => path !== null),
     );
 
     const at = now();
@@ -248,20 +265,32 @@ export function pruneHistory(): { reservations: number; recordings: number; jobs
      * 「終わった予約」は**取り消し・録り逃しか、もう録り始めたもの**。
      * 録り始めたあとの顛末は録画の行が持っているので、予約側では見ない
      */
-    const reservations = database()
-        .prepare(
-            `DELETE FROM reservations
-             WHERE (state IN ('canceled', 'missed') OR started_at IS NOT NULL) AND end_at < ?`,
-        )
-        .run(cutoff).changes;
+    const droppedReservations = affected(
+        orm()
+            .delete(reservations)
+            .where(
+                and(
+                    or(
+                        inArray(reservations.state, ['canceled', 'missed']),
+                        isNotNull(reservations.started_at),
+                    ),
+                    lt(reservations.end_at, cutoff),
+                ),
+            ),
+    );
 
     // 実体はもう無い (deleted_at が立つときに消してある)
-    const recordings = database()
-        .prepare('DELETE FROM recordings WHERE deleted_at IS NOT NULL AND deleted_at < ?')
-        .run(cutoff).changes;
+    const droppedRecordings = affected(
+        orm()
+            .delete(recordings)
+            .where(and(isNotNull(recordings.deleted_at), lt(recordings.deleted_at, cutoff))),
+    );
 
     // 録画の行を消したら、ぶら下がっていたエンコードの記録も要らない
-    database().prepare('DELETE FROM encode_jobs WHERE recording_id NOT IN (SELECT id FROM recordings)').run();
+    orm()
+        .delete(encodeJobs)
+        .where(notInArray(encodeJobs.recording_id, orm().select({ id: recordings.id }).from(recordings)))
+        .run();
 
     /*
      * 終わったエンコードの記録も期限を切る。
@@ -270,19 +299,28 @@ export function pruneHistory(): { reservations: number; recordings: number; jobs
      * (実機で失敗22件)。**いちばん新しい1件だけは残す。** 一覧はそれを見て
      * 「いま失敗しているか」を決めているため、消してしまうと状態が読めなくなる。
      */
-    const jobs = database()
-        .prepare(
-            `DELETE FROM encode_jobs
-             WHERE state IN ('done', 'failed', 'canceled')
-               AND COALESCE(finished_at, created_at) < ?
-               AND id NOT IN (SELECT MAX(id) FROM encode_jobs GROUP BY recording_id)`,
-        )
-        .run(cutoff).changes;
+    const jobs = affected(
+        orm()
+            .delete(encodeJobs)
+            .where(
+                and(
+                    inArray(encodeJobs.state, ['done', 'failed', 'canceled']),
+                    lt(sql`COALESCE(${encodeJobs.finished_at}, ${encodeJobs.created_at})`, cutoff),
+                    notInArray(
+                        encodeJobs.id,
+                        orm()
+                            .select({ id: max(encodeJobs.id) })
+                            .from(encodeJobs)
+                            .groupBy(encodeJobs.recording_id),
+                    ),
+                ),
+            ),
+    );
 
-    if (reservations > 0 || recordings > 0 || jobs > 0) {
+    if (droppedReservations > 0 || droppedRecordings > 0 || jobs > 0) {
         console.log(
-            `[files] 古い履歴を片付けました: 予約 ${reservations} 件 / 録画 ${recordings} 件 / エンコード ${jobs} 件`,
+            `[files] 古い履歴を片付けました: 予約 ${droppedReservations} 件 / 録画 ${droppedRecordings} 件 / エンコード ${jobs} 件`,
         );
     }
-    return { reservations, recordings, jobs };
+    return { reservations: droppedReservations, recordings: droppedRecordings, jobs };
 }

--- a/src/lib/server/live.ts
+++ b/src/lib/server/live.ts
@@ -19,6 +19,7 @@
  * 最後に流した init を持っておいて、繋いできた人に真っ先に渡す。
  */
 
+import { and, eq, gt, lte } from 'drizzle-orm';
 import { type Audio, type AudioTrack, audioTracks, pickTrack } from '$lib/arib';
 import { CHANNEL, type HybridcastLink, type LiveCodec, type Notice } from '$lib/live';
 import { AitReader, APPLICATION_TYPE_HTML5, CONTROL } from '$lib/ts/ait';
@@ -38,8 +39,9 @@ import {
 import { chasePlan, fileSize, followFile } from './chase';
 import { config } from './config';
 import { DataBroadcast, type ResponseMessage } from './databroadcast';
-import { queryOne } from './db';
+import { orm } from './db';
 import { deinterlace } from './encoder';
+import { programs, recordings, services } from './schema';
 import { chunks, lines } from './stream';
 import { openWhenFree } from './tuner';
 import type { Connection } from './ws';
@@ -394,12 +396,11 @@ const RESTING = /休止|停波|放送終了/;
 function resting(serviceId: number): number | null {
     if (!Number.isFinite(serviceId)) return null;
     const at = Date.now();
-    const program = queryOne<{ name: string; end_at: number }>(
-        `SELECT name, end_at FROM programs WHERE service_id = ? AND start_at <= ? AND end_at > ?`,
-        serviceId,
-        at,
-        at,
-    );
+    const program = orm()
+        .select({ name: programs.name, end_at: programs.end_at })
+        .from(programs)
+        .where(airingAt(serviceId, at))
+        .get();
     if (program === undefined || !RESTING.test(program.name)) return null;
     return program.end_at;
 }
@@ -971,18 +972,22 @@ class Session {
      */
     private programInfo(): ResponseMessage | null {
         const at = Date.now();
-        const service = queryOne<{ service_id: number; network_id: number }>(
-            `SELECT service_id, network_id FROM services WHERE id = ?`,
-            this.serviceId,
-        );
+        const service = orm()
+            .select({ service_id: services.service_id, network_id: services.network_id })
+            .from(services)
+            .where(eq(services.id, this.serviceId))
+            .get();
         if (service === undefined) return null;
-        const program = queryOne<{ event_id: number; name: string; start_at: number; end_at: number }>(
-            `SELECT event_id, name, start_at, end_at FROM programs
-             WHERE service_id = ? AND start_at <= ? AND end_at > ?`,
-            this.serviceId,
-            at,
-            at,
-        );
+        const program = orm()
+            .select({
+                event_id: programs.event_id,
+                name: programs.name,
+                start_at: programs.start_at,
+                end_at: programs.end_at,
+            })
+            .from(programs)
+            .where(airingAt(this.serviceId, at))
+            .get();
         return {
             type: 'programInfo',
             originalNetworkId: service.network_id,
@@ -1335,24 +1340,7 @@ function openChase(message: Record<string, unknown>, viewer: Viewer, connection:
     const caption = Number.isInteger(message.caption) ? Math.max(0, Number(message.caption)) : 0;
     if (!Number.isInteger(recordingId)) return refuse('録画が見つかりません');
 
-    const rec = queryOne<{
-        id: number;
-        service_id: number;
-        ts_path: string | null;
-        finished_at: number | null;
-        duration_ms: number | null;
-        start_at: number;
-        end_at: number;
-        created_at: number;
-        audio_type: number | null;
-        audios: string | null;
-        deleted_at: number | null;
-    }>(
-        `SELECT id, service_id, ts_path, finished_at, duration_ms, start_at, end_at,
-                created_at, audio_type, audios, deleted_at
-         FROM recordings WHERE id = ?`,
-        recordingId,
-    );
+    const rec = orm().select().from(recordings).where(eq(recordings.id, recordingId)).get();
     if (rec === undefined || rec.deleted_at !== null || rec.ts_path === null) {
         return refuse('録画が見つかりません');
     }
@@ -1369,9 +1357,7 @@ function openChase(message: Record<string, unknown>, viewer: Viewer, connection:
     const tracks = audioTracks(parseAudios(rec));
     const audio = pickTrack(tracks, wanted);
     // ffmpeg に名指しさせる放送の番号。録画TSは絞ってあるが、探させない理屈はライブと同じ
-    const program =
-        queryOne<{ service_id: number }>(`SELECT service_id FROM services WHERE id = ?`, rec.service_id)
-            ?.service_id ?? 0;
+    const program = aribServiceId(rec.service_id);
 
     tell({
         type: 'tuned',
@@ -1403,10 +1389,11 @@ function openChase(message: Record<string, unknown>, viewer: Viewer, connection:
         () =>
             followFile(path, plan.offset, plan.paceBytesPerSec, () => {
                 // 録り終えたら (行が消えたときも)、尻に着いた時点で読み終わり
-                const row = queryOne<{ finished_at: number | null }>(
-                    `SELECT finished_at FROM recordings WHERE id = ?`,
-                    rec.id,
-                );
+                const row = orm()
+                    .select({ finished_at: recordings.finished_at })
+                    .from(recordings)
+                    .where(eq(recordings.id, rec.id))
+                    .get();
                 return row === undefined || row.finished_at !== null;
             }),
     );
@@ -1452,22 +1439,29 @@ function nowPlaying(serviceId: number, wanted: string | undefined): NowPlaying {
 
     if (!Number.isFinite(serviceId)) return decide(0, []);
     const at = Date.now();
-    const service = queryOne<{ service_id: number }>(
-        `SELECT service_id FROM services WHERE id = ?`,
-        serviceId,
-    );
-    const program = queryOne<{
-        audio_type: number | null;
-        audios: string | null;
-    }>(
-        `SELECT audio_type, audios FROM programs
-         WHERE service_id = ? AND start_at <= ? AND end_at > ?`,
-        serviceId,
-        at,
-        at,
-    );
+    const program = orm()
+        .select({ audio_type: programs.audio_type, audios: programs.audios })
+        .from(programs)
+        .where(airingAt(serviceId, at))
+        .get();
 
-    return decide(service?.service_id ?? 0, parseAudios(program));
+    return decide(aribServiceId(serviceId), parseAudios(program));
+}
+
+/** その局でいま流れている番組 (`programs` の絞り込み) */
+function airingAt(serviceId: number, at: number) {
+    return and(eq(programs.service_id, serviceId), lte(programs.start_at, at), gt(programs.end_at, at));
+}
+
+/** ffmpeg に名指しさせる放送の番号 (ARIB のサービスID)。局が無ければ 0 = 探させない */
+function aribServiceId(serviceId: number): number {
+    return (
+        orm()
+            .select({ service_id: services.service_id })
+            .from(services)
+            .where(eq(services.id, serviceId))
+            .get()?.service_id ?? 0
+    );
 }
 
 /**

--- a/src/lib/server/logo.ts
+++ b/src/lib/server/logo.ts
@@ -1,12 +1,14 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { and, eq, sql } from 'drizzle-orm';
 import { LogoCollector } from '../ts/logo';
 import { withPalette } from '../ts/logo-palette';
 import type { ChannelType } from '../types';
 import { config } from './config';
-import { database, queryAll } from './db';
+import { orm } from './db';
 import { CURRENT_SERVICES } from './epg';
 import { emit } from './events';
+import { services } from './schema';
 import { chunks } from './stream';
 import { type AgentTuner, getTuners, openChannelStream } from './tuner';
 
@@ -217,12 +219,12 @@ function store(networkId: number, serviceIds: number[], data: Uint8Array): numbe
 
     let saved = 0;
     for (const serviceId of serviceIds) {
-        const service = queryAll<{ id: number }>(
-            'SELECT id FROM services WHERE network_id = ? AND service_id = ?',
-            networkId,
-            serviceId,
-        );
-        for (const { id } of service) {
+        const matched = orm()
+            .select({ id: services.id })
+            .from(services)
+            .where(and(eq(services.network_id, networkId), eq(services.service_id, serviceId)))
+            .all();
+        for (const { id } of matched) {
             // 書きかけを読ませない。番組表は同時に見に来る
             const working = `${logoPath(id)}.writing`;
             writeFileSync(working, data);
@@ -234,7 +236,7 @@ function store(networkId: number, serviceIds: number[], data: Uint8Array): numbe
              * 頃は、**その局だけが「いまの局」になって番組表から他が消えていた**
              * (次の取り込みまで)。ロゴを拾ったことは取り込みとは何の関係もない
              */
-            database().prepare('UPDATE services SET has_logo = 1 WHERE id = ?').run(id);
+            orm().update(services).set({ has_logo: 1 }).where(eq(services.id, id)).run();
             saved++;
         }
     }
@@ -309,19 +311,17 @@ export interface Feed {
  * 拾い直すと局によっては何時間もかかるので、置いてあるものを直す。
  */
 export function reconcile(): number {
-    const rows = queryAll<{ id: number; has_logo: number }>('SELECT id, has_logo FROM services');
-    const fix = database().prepare('UPDATE services SET has_logo = ? WHERE id = ?');
+    const rows = orm().select({ id: services.id, has_logo: services.has_logo }).from(services).all();
     let changed = 0;
-    const tx = database().transaction(() => {
+    orm().transaction((tx) => {
         for (const row of rows) {
             const actual = existsSync(logoPath(row.id)) ? 1 : 0;
             if (actual === 1) repaint(row.id);
             if (actual === row.has_logo) continue;
-            fix.run(actual, row.id);
+            tx.update(services).set({ has_logo: actual }).where(eq(services.id, row.id)).run();
             changed++;
         }
     });
-    tx();
     if (changed > 0) emit('services');
     return changed;
 }
@@ -379,11 +379,17 @@ function needsLogo(serviceId: number): boolean {
 
 /** いま選局できる局。取り残しは見に行かない */
 function currentServices(): { id: number; type: string; channel: string; network_id: number }[] {
-    return queryAll(
-        `SELECT id, type, channel, network_id FROM services
-         WHERE ${CURRENT_SERVICES}
-         ORDER BY type, channel`,
-    );
+    return orm()
+        .select({
+            id: services.id,
+            type: services.type,
+            channel: services.channel,
+            network_id: services.network_id,
+        })
+        .from(services)
+        .where(sql.raw(CURRENT_SERVICES))
+        .orderBy(services.type, services.channel)
+        .all();
 }
 
 export function missing(): Target[] {

--- a/src/lib/server/migrate.ts
+++ b/src/lib/server/migrate.ts
@@ -13,13 +13,14 @@
 import { copyFileSync, existsSync, mkdirSync, renameSync, statSync, unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { SQL } from 'bun';
+import { and, eq, isNull } from 'drizzle-orm';
 import { parseSearchFields, SEARCH_FIELDS } from '$lib/search';
-import type { Recording } from '$lib/types';
-import { database, now, queryOne } from './db';
+import { now, orm } from './db';
 import { emit } from './events';
 import { libraryPath, recordedPath } from './library';
 import { writeThumbnail } from './metadata';
 import { reserve } from './reservations';
+import { programs, recordings, rules, services } from './schema';
 import { parseTitle, toHalfWidth } from './title';
 
 const env = (key: string, fallback: string) => process.env[key] ?? fallback;
@@ -186,10 +187,11 @@ async function fetchRows(): Promise<Row[]> {
 /** 1件を取り込む。取り込めたかどうかを返す */
 async function importOne(row: Row, options: MigrateOptions): Promise<'imported' | 'skipped' | 'missing'> {
     // 取り込み済みは EPGStation 側のIDで判別する
-    const already = queryOne<{ id: number }>(
-        `SELECT id FROM recordings WHERE program_id = ? AND reservation_id IS NULL`,
-        -row.id,
-    );
+    const already = orm()
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(and(eq(recordings.program_id, -row.id), isNull(recordings.reservation_id)))
+        .get();
     if (already !== undefined) return 'skipped';
 
     if (row.filePath === null) {
@@ -207,40 +209,40 @@ async function importOne(row: Row, options: MigrateOptions): Promise<'imported' 
     if (!options.apply) return 'imported';
 
     const parsed = parseTitle(name);
-    const service = queryOne<{ id: number; name: string }>(
-        'SELECT id, name FROM services WHERE network_id = ? AND service_id = ?',
-        row.networkId,
-        row.serviceId,
-    );
+    // 局が分からない行 (networkId / serviceId が NULL) は照合しない。局名だけ写す
+    const service =
+        row.networkId === null || row.serviceId === null
+            ? undefined
+            : orm()
+                  .select({ id: services.id, name: services.name })
+                  .from(services)
+                  .where(and(eq(services.network_id, row.networkId), eq(services.service_id, row.serviceId)))
+                  .get();
 
     const at = now();
     // program_id は EPGStation のIDの符号を反転して入れる。
     // denpa の番組IDと衝突せず、二重取り込みの判定にも使える
-    const info = database()
-        .prepare(
-            // 録り終えた時刻を入れておく。あとでファイルの置き場所が入れば「視聴可能」になる
-            `INSERT INTO recordings
-                (reservation_id, program_id, service_id, service_name, name, series, subtitle,
-                 description, start_at, end_at, finished_at, created_at, updated_at)
-             VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        )
-        .run(
-            -row.id,
-            service?.id ?? 0,
-            service?.name ?? toHalfWidth(row.channelName ?? ''),
+    const { id } = orm()
+        .insert(recordings)
+        // 録り終えた時刻を入れておく。あとでファイルの置き場所が入れば「視聴可能」になる
+        .values({
+            reservation_id: null,
+            program_id: -row.id,
+            service_id: service?.id ?? 0,
+            service_name: service?.name ?? toHalfWidth(row.channelName ?? ''),
             name,
-            parsed.series,
-            parsed.subtitle,
-            toHalfWidth(row.description ?? ''),
-            Number(row.startAt),
-            Number(row.endAt),
-            at,
-            at,
-            at,
-        );
-
-    const id = Number(info.lastInsertRowid);
-    const recording = queryOne<Recording>('SELECT * FROM recordings WHERE id = ?', id)!;
+            series: parsed.series,
+            subtitle: parsed.subtitle,
+            description: toHalfWidth(row.description ?? ''),
+            start_at: Number(row.startAt),
+            end_at: Number(row.endAt),
+            finished_at: at,
+            created_at: at,
+            updated_at: at,
+        })
+        .returning({ id: recordings.id })
+        .get()!;
+    const recording = orm().select().from(recordings).where(eq(recordings.id, id)).get()!;
 
     /*
      * 生TSは保存先ではなく作業領域へ置く。
@@ -267,10 +269,12 @@ async function importOne(row: Row, options: MigrateOptions): Promise<'imported' 
         copyFileSync(from, to);
     }
 
-    const column = raw ? 'ts_path' : 'library_path';
-    database()
-        .prepare(`UPDATE recordings SET ${column} = ?, ts_size = ?, updated_at = ? WHERE id = ?`)
-        .run(to, statSync(to).size, now(), id);
+    const placed = raw ? { ts_path: to } : { library_path: to };
+    orm()
+        .update(recordings)
+        .set({ ...placed, ts_size: statSync(to).size, updated_at: now() })
+        .where(eq(recordings.id, id))
+        .run();
 
     // サムネイルは保存先に置いたものにだけ付ける。作業領域は画面に出ない
     if (!raw) {
@@ -308,11 +312,16 @@ interface ReserveRow {
 
 /** EPGStation のチャンネルIDは networkId * 100000 + serviceId */
 function serviceIdFor(channelId: number): number | undefined {
-    const service = queryOne<{ id: number }>(
-        'SELECT id FROM services WHERE network_id = ? AND service_id = ?',
-        Math.floor(channelId / 100000),
-        channelId % 100000,
-    );
+    const service = orm()
+        .select({ id: services.id })
+        .from(services)
+        .where(
+            and(
+                eq(services.network_id, Math.floor(channelId / 100000)),
+                eq(services.service_id, channelId % 100000),
+            ),
+        )
+        .get();
     return service?.id;
 }
 
@@ -364,7 +373,7 @@ async function importRules(connection: SQL, options: MigrateOptions): Promise<vo
 
     for (const row of rows) {
         const source = `epgstation:${row.id}`;
-        if (queryOne<{ id: number }>('SELECT id FROM rules WHERE source = ?', source) !== undefined) {
+        if (orm().select({ id: rules.id }).from(rules).where(eq(rules.source, source)).get() !== undefined) {
             status_.rules.skipped++;
             continue;
         }
@@ -404,26 +413,26 @@ async function importRules(connection: SQL, options: MigrateOptions): Promise<vo
             continue;
         }
 
-        database()
-            .prepare(
-                // 焼き方は引き継がない。エンコードもCMも全体設定で、焼くときに読む
-                `INSERT INTO rules (name, keyword, ignore_keyword, search_fields, service_ids, service_types,
-                                    genres, enabled, priority, source, created_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
-            )
-            .run(
+        // 焼き方は引き継がない。エンコードもCMも全体設定で、焼くときに読む
+        orm()
+            .insert(rules)
+            .values({
                 name,
                 keyword,
-                toHalfWidth(row.ignoreKeyword ?? '').trim(),
+                ignore_keyword: toHalfWidth(row.ignoreKeyword ?? '').trim(),
                 // 当てる範囲も向こうから引き継ぐ。既定に寄せると黙って当たらなくなる
-                parseSearchFields(SEARCH_FIELDS.filter((field) => row[field] === 1).join(',')).join(','),
-                channels.length === 0 ? null : JSON.stringify(channels),
-                types.length === 0 ? null : JSON.stringify(types),
-                genreIds.length === 0 ? null : JSON.stringify(genreIds),
-                row.enable ? 1 : 0,
+                search_fields: parseSearchFields(
+                    SEARCH_FIELDS.filter((field) => row[field] === 1).join(','),
+                ).join(','),
+                service_ids: channels.length === 0 ? null : JSON.stringify(channels),
+                service_types: types.length === 0 ? null : JSON.stringify(types),
+                genres: genreIds.length === 0 ? null : JSON.stringify(genreIds),
+                enabled: row.enable ? 1 : 0,
+                priority: 1,
                 source,
-                now(),
-            );
+                created_at: now(),
+            })
+            .run();
         status_.rules.imported++;
     }
 }
@@ -446,7 +455,14 @@ async function importReservations(connection: SQL, options: MigrateOptions): Pro
             status_.reservations.skipped++;
             continue;
         }
-        const program = queryOne<{ id: number }>('SELECT id FROM programs WHERE id = ?', row.programId);
+        const program =
+            row.programId === null
+                ? undefined
+                : orm()
+                      .select({ id: programs.id })
+                      .from(programs)
+                      .where(eq(programs.id, row.programId))
+                      .get();
         if (program === undefined) {
             // 番組表を取り込む前だと出る。EPG を取り直してからもう一度実行すれば入る
             record(`番組表に無いので取り込めません: ${toHalfWidth(row.name ?? String(row.programId))}`);

--- a/src/lib/server/recorder.ts
+++ b/src/lib/server/recorder.ts
@@ -1,17 +1,19 @@
 import { once } from 'node:events';
 import { createWriteStream, mkdirSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { eq, sql } from 'drizzle-orm';
 import { EpgReader } from '../ts/eit';
 import { ServiceFilter } from '../ts/service-filter';
-import type { Program, Recording, Reservation, Service } from '../types';
+import type { Recording, Reservation } from '../types';
 import { config } from './config';
-import { database, now, queryOne } from './db';
+import { now, orm } from './db';
 import { enqueue } from './encoder';
 import { savePrograms } from './epg';
 import { emit } from './events';
 import { moveFile } from './fsx';
 import { libraryPath, recordedPath } from './library';
 import { writeThumbnail } from './metadata';
+import { programs, recordings, reservations, services } from './schema';
 import { chunks } from './stream';
 import { parseTitle } from './title';
 import { openChannelStream } from './tuner';
@@ -44,13 +46,12 @@ function fail(recordingId: number, error: string): void {
      * 理由を書けば状態は決まる (recordings.state は生成列)。
      * 掴むのも終わりなので、録り終えた時刻も同時に埋める
      */
-    database()
-        .prepare(
-            `UPDATE recordings SET error = ?, finished_at = COALESCE(finished_at, ?), updated_at = ?
-             WHERE id = ?`,
-        )
-        .run(error, now(), now(), recordingId);
-    const rec = queryOne<Recording>('SELECT * FROM recordings WHERE id = ?', recordingId);
+    orm()
+        .update(recordings)
+        .set({ error, finished_at: sql`COALESCE(${recordings.finished_at}, ${now()})`, updated_at: now() })
+        .where(eq(recordings.id, recordingId))
+        .run();
+    const rec = recordingById(recordingId);
     if (rec !== undefined) {
         notify({
             event: 'recording.failed',
@@ -62,9 +63,13 @@ function fail(recordingId: number, error: string): void {
     // 予約側には何も書かない。失敗したことは録画の行が持っている
 }
 
+function recordingById(id: number): Recording | undefined {
+    return orm().select().from(recordings).where(eq(recordings.id, id)).get();
+}
+
 function createRecording(reservation: Reservation): Recording {
-    const service = queryOne<Service>('SELECT * FROM services WHERE id = ?', reservation.service_id);
-    const program = queryOne<Program>('SELECT * FROM programs WHERE id = ?', reservation.program_id);
+    const service = orm().select().from(services).where(eq(services.id, reservation.service_id)).get();
+    const program = orm().select().from(programs).where(eq(programs.id, reservation.program_id)).get();
 
     /*
      * 名前と概要は**録り始める瞬間の番組表**から取る。
@@ -83,44 +88,38 @@ function createRecording(reservation: Reservation): Recording {
     const parsed = parseTitle(name);
     const at = now();
 
-    const info = database()
-        .prepare(
-            // finished_at を入れないので、この行は「録画中」として読まれる
-            `INSERT INTO recordings
-                (reservation_id, program_id, service_id, service_name, name, series, subtitle,
-                 description, extended, start_at, end_at, record_from, record_to, audio_type,
-                 genre_detail, audios, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        )
-        .run(
-            reservation.id,
-            reservation.program_id,
-            reservation.service_id,
-            service?.name ?? '',
+    const { id } = orm()
+        .insert(recordings)
+        // finished_at を入れないので、この行は「録画中」として読まれる
+        .values({
+            reservation_id: reservation.id,
+            program_id: reservation.program_id,
+            service_id: reservation.service_id,
+            service_name: service?.name ?? '',
             name,
-            parsed.series,
-            parsed.subtitle,
+            series: parsed.series,
+            subtitle: parsed.subtitle,
             description,
             extended,
-            reservation.start_at,
-            reservation.end_at,
+            start_at: reservation.start_at,
+            end_at: reservation.end_at,
             /*
              * **譲った区間を写す。** チューナーの取り合いで頭か尻を譲ったときだけ
              * 入っている (`conflict.ts` の「入るところまで録る」)。一覧で
              * 「頭が欠けている」と言うのに要る
              */
-            reservation.record_from,
-            reservation.record_to,
-            program?.audio_type ?? null,
+            record_from: reservation.record_from,
+            record_to: reservation.record_to,
+            audio_type: program?.audio_type ?? null,
             // 番組表の行は24時間で消える。録り直しのときにも要るので写しておく
-            program?.genre_detail ?? null,
+            genre_detail: program?.genre_detail ?? null,
             // 焼いたものの音声トラックに番組表と同じ名前を入れるのに要る (`audioTitles`)
-            program?.audios ?? null,
-            at,
-            at,
-        );
-
-    const id = Number(info.lastInsertRowid);
+            audios: program?.audios ?? null,
+            created_at: at,
+            updated_at: at,
+        })
+        .returning({ id: recordings.id })
+        .get()!;
     // ファイル名は録画IDを含めるため、行を作ってからでないと決まらない
     const path = recordedPath({
         id,
@@ -128,9 +127,9 @@ function createRecording(reservation: Reservation): Recording {
         subtitle: parsed.subtitle,
         start_at: reservation.start_at,
     });
-    database().prepare('UPDATE recordings SET ts_path = ? WHERE id = ?').run(path, id);
+    orm().update(recordings).set({ ts_path: path }).where(eq(recordings.id, id)).run();
 
-    return queryOne<Recording>('SELECT * FROM recordings WHERE id = ?', id)!;
+    return recordingById(id)!;
 }
 
 /**
@@ -195,17 +194,25 @@ async function openWithRetry(
  * 実際にはまだ流れていたときに取り返しがつかない。
  */
 function extendIfLonger(recording: Recording, endAt: number): void {
-    const current = queryOne<{ end_at: number }>('SELECT end_at FROM recordings WHERE id = ?', recording.id);
+    const current = orm()
+        .select({ end_at: recordings.end_at })
+        .from(recordings)
+        .where(eq(recordings.id, recording.id))
+        .get();
     if (current === undefined || endAt <= current.end_at) return;
 
     const at = now();
-    database()
-        .prepare('UPDATE recordings SET end_at = ?, updated_at = ? WHERE id = ?')
-        .run(endAt, at, recording.id);
+    orm()
+        .update(recordings)
+        .set({ end_at: endAt, updated_at: at })
+        .where(eq(recordings.id, recording.id))
+        .run();
     if (recording.reservation_id !== null) {
-        database()
-            .prepare('UPDATE reservations SET end_at = ?, updated_at = ? WHERE id = ?')
-            .run(endAt, at, recording.reservation_id);
+        orm()
+            .update(reservations)
+            .set({ end_at: endAt, updated_at: at })
+            .where(eq(reservations.id, recording.reservation_id))
+            .run();
     }
     const minutes = Math.round((endAt - current.end_at) / 60000);
     console.log(`[rec] 放送が延びました: ${recording.name} (+${minutes}分)`);
@@ -216,9 +223,11 @@ function extendIfLonger(recording: Recording, endAt: number): void {
 /** 実際に録れた長さを足す。再開したぶんも合算するので加算にする */
 function addDuration(recordingId: number, ms: number): void {
     if (ms <= 0) return;
-    database()
-        .prepare('UPDATE recordings SET duration_ms = COALESCE(duration_ms, 0) + ? WHERE id = ?')
-        .run(ms, recordingId);
+    orm()
+        .update(recordings)
+        .set({ duration_ms: sql`COALESCE(${recordings.duration_ms}, 0) + ${ms}` })
+        .where(eq(recordings.id, recordingId))
+        .run();
 }
 
 /**
@@ -234,7 +243,7 @@ async function pump(recording: Recording, controller: AbortController): Promise<
     const path = recording.ts_path!;
     mkdirSync(dirname(path), { recursive: true });
 
-    const service = queryOne<Service>('SELECT * FROM services WHERE id = ?', recording.service_id);
+    const service = orm().select().from(services).where(eq(services.id, recording.service_id)).get();
     if (service === undefined) {
         fail(recording.id, '局の情報がありません。チャンネルスキャンをやり直してください');
         active.delete(recording.id);
@@ -395,18 +404,21 @@ async function pump(recording: Recording, controller: AbortController): Promise<
 export function finish(recordingId: number, size: number): void {
     const at = now();
     // 録り終えた時刻が入った時点で「録画済み」になる (recordings.state は生成列)
-    database()
-        .prepare(`UPDATE recordings SET finished_at = ?, ts_size = ?, updated_at = ? WHERE id = ?`)
-        .run(at, size, at, recordingId);
+    orm()
+        .update(recordings)
+        .set({ finished_at: at, ts_size: size, updated_at: at })
+        .where(eq(recordings.id, recordingId))
+        .run();
 
-    const recording = queryOne<Recording>('SELECT * FROM recordings WHERE id = ?', recordingId)!;
+    const recording = recordingById(recordingId)!;
     const reservation =
         recording.reservation_id == null
             ? undefined
-            : queryOne<{ encode: number }>(
-                  'SELECT encode FROM reservations WHERE id = ?',
-                  recording.reservation_id,
-              );
+            : orm()
+                  .select({ encode: reservations.encode })
+                  .from(reservations)
+                  .where(eq(reservations.id, recording.reservation_id))
+                  .get();
 
     emit('recordings');
     notify({
@@ -424,12 +436,12 @@ export function finish(recordingId: number, size: number): void {
     const dest = libraryPath(recording, '.m2ts');
     moveFile(recording.ts_path!, dest);
     void writeThumbnail(dest, (recording.end_at - recording.start_at) / 1000);
-    database()
-        .prepare(
-            // 保存先に置いた時点で「視聴可能」になる
-            `UPDATE recordings SET library_path = ?, ts_path = NULL, updated_at = ? WHERE id = ?`,
-        )
-        .run(dest, now(), recording.id);
+    // 保存先に置いた時点で「視聴可能」になる
+    orm()
+        .update(recordings)
+        .set({ library_path: dest, ts_path: null, updated_at: now() })
+        .where(eq(recordings.id, recording.id))
+        .run();
 }
 
 /**
@@ -441,9 +453,7 @@ export function finish(recordingId: number, size: number): void {
  * 放送が終わってしまったものは、もう取り返せないので失敗に倒す。
  */
 export function recoverOrphanedRecordings(): { resumed: number; failed: number } {
-    const orphans = database()
-        .prepare(`SELECT * FROM recordings WHERE state = 'recording'`)
-        .all() as Recording[];
+    const orphans = orm().select().from(recordings).where(eq(recordings.state, 'recording')).all();
 
     let resumed = 0;
     let failed = 0;

--- a/src/lib/server/scheduler.ts
+++ b/src/lib/server/scheduler.ts
@@ -1,9 +1,11 @@
+import { and, eq, getTableColumns, gt, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import type { Reservation } from '../types';
 import { config } from './config';
 import { assign, whole } from './conflict';
-import { database, now, queryOne } from './db';
+import { affected, now, orm } from './db';
 import { emit } from './events';
 import { activeRecordingIds, startRecording, stopRecording } from './recorder';
+import { recordings, reservations, services } from './schema';
 import { isDraining } from './shutdown';
 import { type AgentTuner, getTuners } from './tuner';
 
@@ -36,16 +38,20 @@ export async function tunerCapacity(): Promise<Map<string, number>> {
 
 export async function resolveConflicts(): Promise<{ accepted: number; rejected: number }> {
     const capacity = await tunerCapacity();
-    const candidates = database()
-        .prepare(
-            `SELECT r.*, s.type AS type, s.channel AS channel
-             FROM reservations r
-             JOIN services s ON s.id = r.service_id
-             -- 録り始めたものは数え直さない。掴む本数はもう決まっている
-             WHERE r.state IN ('scheduled', 'conflict') AND r.started_at IS NULL AND r.end_at > ?
-             ORDER BY r.start_at`,
+    const candidates: Candidate[] = orm()
+        .select({ ...getTableColumns(reservations), type: services.type, channel: services.channel })
+        .from(reservations)
+        .innerJoin(services, eq(services.id, reservations.service_id))
+        .where(
+            and(
+                inArray(reservations.state, ['scheduled', 'conflict']),
+                // 録り始めたものは数え直さない。掴む本数はもう決まっている
+                isNull(reservations.started_at),
+                gt(reservations.end_at, now()),
+            ),
         )
-        .all(now()) as Candidate[];
+        .orderBy(reservations.start_at)
+        .all();
 
     // 前後のマージンぶんチューナーを掴む時間は延びる。予約表と実行時のズレを無くすため
     // 同じ物差しで数える
@@ -55,32 +61,38 @@ export async function resolveConflicts(): Promise<{ accepted: number; rejected: 
     });
 
     const at = now();
-    const toScheduled = database().prepare(
-        `UPDATE reservations SET state = 'scheduled', conflict_reason = NULL, updated_at = ?
-         WHERE id = ? AND state = 'conflict'`,
-    );
-    const toConflict = database().prepare(
-        `UPDATE reservations SET state = 'conflict', conflict_reason = ?, updated_at = ?
-         WHERE id = ? AND state = 'scheduled'`,
-    );
-    /*
-     * **譲ったぶんを覚える。** 丸ごと入ったものは NULL に戻す —
-     * 前の回で削られていても、相手が消えれば丸ごと録れるようになる
-     */
-    const setWindow = database().prepare(
-        `UPDATE reservations SET record_from = ?, record_to = ?, updated_at = ?
-         WHERE id = ? AND (record_from IS NOT ? OR record_to IS NOT ?)`,
-    );
-    const tx = database().transaction(() => {
+    orm().transaction((tx) => {
         for (const a of accepted) {
-            toScheduled.run(at, a.reservation.id);
+            tx.update(reservations)
+                .set({ state: 'scheduled', conflict_reason: null, updated_at: at })
+                .where(and(eq(reservations.id, a.reservation.id), eq(reservations.state, 'conflict')))
+                .run();
+            /*
+             * **譲ったぶんを覚える。** 丸ごと入ったものは NULL に戻す —
+             * 前の回で削られていても、相手が消えれば丸ごと録れるようになる
+             */
             const from = whole(a) ? null : a.from;
             const to = whole(a) ? null : a.to;
-            setWindow.run(from, to, at, a.reservation.id, from, to);
+            tx.update(reservations)
+                .set({ record_from: from, record_to: to, updated_at: at })
+                .where(
+                    and(
+                        eq(reservations.id, a.reservation.id),
+                        or(
+                            sql`${reservations.record_from} IS NOT ${from}`,
+                            sql`${reservations.record_to} IS NOT ${to}`,
+                        ),
+                    ),
+                )
+                .run();
         }
-        for (const r of rejected) toConflict.run(r.reason, at, r.reservation.id);
+        for (const r of rejected) {
+            tx.update(reservations)
+                .set({ state: 'conflict', conflict_reason: r.reason, updated_at: at })
+                .where(and(eq(reservations.id, r.reservation.id), eq(reservations.state, 'scheduled')))
+                .run();
+        }
     });
-    tx();
     emit('reservations');
 
     return { accepted: accepted.length, rejected: rejected.length };
@@ -96,10 +108,11 @@ export async function tick(): Promise<void> {
     // 止めるほうを先にやる。次の番組が始まるときに前の録画がまだチューナーを
     // 掴んでいると、本数が足りない環境で後続が丸ごと録れない
     for (const id of activeRecordingIds()) {
-        const rec = queryOne<{ end_at: number; record_to: number | null }>(
-            'SELECT end_at, record_to FROM recordings WHERE id = ?',
-            id,
-        );
+        const rec = orm()
+            .select({ end_at: recordings.end_at, record_to: recordings.record_to })
+            .from(recordings)
+            .where(eq(recordings.id, id))
+            .get();
         if (rec === undefined) continue;
         // 尻を譲っているならそこで離す (`record_to`)。次の録画がそこから掴む
         const until = rec.record_to ?? rec.end_at + config.endMargin;
@@ -108,13 +121,19 @@ export async function tick(): Promise<void> {
 
     // 始まらないまま終わってしまった予約を片付ける。
     // アプリが止まっていた間に放送が終わったものがここに残り続けていた
-    const expired = database()
-        .prepare(
-            `UPDATE reservations SET state = 'missed', updated_at = ?
-             WHERE state IN ('scheduled', 'conflict') AND started_at IS NULL AND end_at <= ?`,
-        )
-        .run(at, at);
-    if (expired.changes > 0) emit('reservations');
+    const expired = affected(
+        orm()
+            .update(reservations)
+            .set({ state: 'missed', updated_at: at })
+            .where(
+                and(
+                    inArray(reservations.state, ['scheduled', 'conflict']),
+                    isNull(reservations.started_at),
+                    lte(reservations.end_at, at),
+                ),
+            ),
+    );
+    if (expired > 0) emit('reservations');
 
     /*
      * **止められている最中でも始める。**
@@ -133,14 +152,21 @@ export async function tick(): Promise<void> {
      * **譲ったぶんがあれば、そちらを見る** (`record_from`)。チューナーの取り合いで
      * 頭を譲った予約は、番組の始まりに起こしても掴めない — 相手がまだ掴んでいる
      */
-    const due = database()
-        .prepare(
-            `SELECT * FROM reservations
-             WHERE state = 'scheduled' AND started_at IS NULL
-               AND COALESCE(record_from, start_at - ?) <= ?
-               AND COALESCE(record_to, end_at) > ?`,
+    const due = orm()
+        .select()
+        .from(reservations)
+        .where(
+            and(
+                eq(reservations.state, 'scheduled'),
+                isNull(reservations.started_at),
+                lte(
+                    sql`COALESCE(${reservations.record_from}, ${reservations.start_at} - ${config.startMargin})`,
+                    at,
+                ),
+                gt(sql`COALESCE(${reservations.record_to}, ${reservations.end_at})`, at),
+            ),
         )
-        .all(config.startMargin, at, at) as Reservation[];
+        .all();
     // 5秒ごとに言わない。**始めるものがあるときだけ**
     if (due.length > 0 && isDraining()) {
         console.log(`[録画] 止まる途中ですが ${due.length} 件始めます (頭を落とさないため)`);
@@ -152,13 +178,19 @@ export async function tick(): Promise<void> {
          * 状態の文字列を 'recording' に進めていた頃と同じ鍵の掛け方だが、
          * こちらは録画の行と食い違いようがない (録り始めたかどうかは事実ひとつ)
          */
-        const claimed = database()
-            .prepare(
-                `UPDATE reservations SET started_at = ?, updated_at = ?
-                 WHERE id = ? AND started_at IS NULL AND state = 'scheduled'`,
+        const claimed = orm()
+            .update(reservations)
+            .set({ started_at: at, updated_at: at })
+            .where(
+                and(
+                    eq(reservations.id, reservation.id),
+                    isNull(reservations.started_at),
+                    eq(reservations.state, 'scheduled'),
+                ),
             )
-            .run(at, at, reservation.id);
-        if (claimed.changes === 0) continue;
+            .returning({ id: reservations.id })
+            .get();
+        if (claimed === undefined) continue;
         await startRecording(reservation);
     }
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,12 +1,13 @@
 import { statSync } from 'node:fs';
 import { fail } from '@sveltejs/kit';
-import { database, queryAll } from '$lib/server/db';
+import { and, eq, isNull } from 'drizzle-orm';
+import { database, orm, queryAll } from '$lib/server/db';
 import { cancel as cancelEncode, enqueue, pump } from '$lib/server/encoder';
 import { emit } from '$lib/server/events';
 import { deleteRecordingFiles, reconcile } from '$lib/server/files';
 import { recordingFromForm } from '$lib/server/recording';
 import { cancel, restore } from '$lib/server/reservations';
-import { RESERVATION_STATE } from '$lib/server/schema';
+import { RESERVATION_STATE, reservations as reservationTable } from '$lib/server/schema';
 import { settings } from '$lib/server/settings';
 import { targets } from '$lib/server/vlc';
 import { encodeSource } from '$lib/source';
@@ -331,10 +332,18 @@ export const actions = {
         const id = Number(form.get('id'));
         if (!Number.isFinite(id)) return fail(400, { message: 'IDが不正です' });
         // 状態も見て消す。録り逃し以外 (これからの予約など) を同じ口で消させない
-        const gone = database()
-            .prepare(`DELETE FROM reservations WHERE id = ? AND state = 'missed' AND started_at IS NULL`)
-            .run(id);
-        if (gone.changes === 0) return fail(400, { message: '録り逃した予約ではありません' });
+        const gone = orm()
+            .delete(reservationTable)
+            .where(
+                and(
+                    eq(reservationTable.id, id),
+                    eq(reservationTable.state, 'missed'),
+                    isNull(reservationTable.started_at),
+                ),
+            )
+            .returning({ id: reservationTable.id })
+            .get();
+        if (gone === undefined) return fail(400, { message: '録り逃した予約ではありません' });
         // 他の端末の画面にも反映する
         emit('reservations');
         return { success: true };

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,6 +1,8 @@
 import { json } from '@sveltejs/kit';
-import { queryOne } from '$lib/server/db';
+import { count } from 'drizzle-orm';
+import { orm } from '$lib/server/db';
 import { activeRecordingIds } from '$lib/server/recorder';
+import { services } from '$lib/server/schema';
 
 /**
  * compose の healthcheck と E2E の起動待ちに使う。DBまで触って初めて ok を返す。
@@ -9,6 +11,6 @@ import { activeRecordingIds } from '$lib/server/recorder';
  * (待つこと自体はアプリ側でやっている。runtime.ts の drain)。
  */
 export function GET() {
-    const row = queryOne<{ n: number }>('SELECT COUNT(*) AS n FROM services');
+    const row = orm().select({ n: count() }).from(services).get();
     return json({ ok: true, services: row?.n ?? 0, recording: activeRecordingIds().length });
 }

--- a/src/routes/api/programs/[id]/+server.ts
+++ b/src/routes/api/programs/[id]/+server.ts
@@ -1,5 +1,7 @@
 import { error, json } from '@sveltejs/kit';
-import { queryOne } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import { orm } from '$lib/server/db';
+import { programs, services } from '$lib/server/schema';
 import type { ProgramDetail } from '$lib/types';
 
 /**
@@ -15,14 +17,24 @@ export function GET({ params }) {
     const id = Number(params.id);
     if (!Number.isFinite(id)) error(400, '番組IDが不正です');
 
-    const program = queryOne<ProgramDetail>(
-        `SELECT p.name, p.description, p.extended, p.genre_detail, p.audios,
-                p.video_type, p.video_resolution, p.is_free, p.start_at, p.end_at,
-                s.name AS service_name
-         FROM programs p JOIN services s ON s.id = p.service_id
-         WHERE p.id = ?`,
-        id,
-    );
+    const program: ProgramDetail | undefined = orm()
+        .select({
+            name: programs.name,
+            description: programs.description,
+            extended: programs.extended,
+            genre_detail: programs.genre_detail,
+            audios: programs.audios,
+            video_type: programs.video_type,
+            video_resolution: programs.video_resolution,
+            is_free: programs.is_free,
+            start_at: programs.start_at,
+            end_at: programs.end_at,
+            service_name: services.name,
+        })
+        .from(programs)
+        .innerJoin(services, eq(services.id, programs.service_id))
+        .where(eq(programs.id, id))
+        .get();
     if (program === undefined) error(404, '番組が見つかりません');
 
     return json(program);

--- a/src/routes/guide/+page.server.ts
+++ b/src/routes/guide/+page.server.ts
@@ -1,8 +1,14 @@
 import { fail } from '@sveltejs/kit';
-import { queryAll, queryOne } from '$lib/server/db';
+import { and, eq, gt, lte, ne, sql } from 'drizzle-orm';
+import { orm, queryAll } from '$lib/server/db';
 import { airing, CURRENT_SERVICES, SERVICE_ORDER } from '$lib/server/epg';
 import { cancel, reserve } from '$lib/server/reservations';
-import { RESERVATION_STATE } from '$lib/server/schema';
+import {
+    programs as programTable,
+    RESERVATION_STATE,
+    reservations,
+    services as serviceTable,
+} from '$lib/server/schema';
 import type { ChannelType, Program, Service } from '$lib/types';
 
 const HOUR = 60 * 60 * 1000;
@@ -49,11 +55,12 @@ export async function load({ url }) {
 
     // テレビと同じ並びにする (SERVICE_ORDER)。
     // 取り残しの局は出さない (CURRENT_SERVICES)。出すと番組表に空の列が並ぶ
-    const services = queryAll<Service>(
-        `SELECT * FROM services WHERE type = ? AND ${CURRENT_SERVICES}
-         ORDER BY ${SERVICE_ORDER}`,
-        type,
-    );
+    const services: Service[] = orm()
+        .select()
+        .from(serviceTable)
+        .where(and(eq(serviceTable.type, type), sql.raw(CURRENT_SERVICES)))
+        .orderBy(sql.raw(SERVICE_ORDER))
+        .all();
     const programs = queryAll<GridProgram>(
         /*
          * 予約の状態は録画の行から引く (RESERVATION_STATE)。r.state をそのまま
@@ -93,12 +100,12 @@ export async function load({ url }) {
      */
     const at = Date.now();
     const watchable = airing(
-        queryAll<{ id: number }>(`SELECT id FROM services WHERE ${CURRENT_SERVICES}`),
-        queryAll<{ service_id: number; name: string }>(
-            `SELECT service_id, name FROM programs WHERE start_at <= ? AND end_at > ?`,
-            at,
-            at,
-        ),
+        orm().select({ id: serviceTable.id }).from(serviceTable).where(sql.raw(CURRENT_SERVICES)).all(),
+        orm()
+            .select({ service_id: programTable.service_id, name: programTable.name })
+            .from(programTable)
+            .where(and(lte(programTable.start_at, at), gt(programTable.end_at, at)))
+            .all(),
     ).map((service) => service.id);
 
     return {
@@ -118,10 +125,11 @@ export const actions = {
         const form = await request.formData();
         const programId = Number(form.get('programId'));
         if (!Number.isFinite(programId)) return fail(400, { message: '番組IDが不正です' });
-        const reservation = queryOne<{ id: number }>(
-            `SELECT id FROM reservations WHERE program_id = ? AND state != 'canceled'`,
-            programId,
-        );
+        const reservation = orm()
+            .select({ id: reservations.id })
+            .from(reservations)
+            .where(and(eq(reservations.program_id, programId), ne(reservations.state, 'canceled')))
+            .get();
         if (reservation === undefined) return fail(404, { message: '予約が見つかりません' });
         await cancel(reservation.id);
         return { success: true };

--- a/src/routes/rules/+page.server.ts
+++ b/src/routes/rules/+page.server.ts
@@ -1,16 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
+import { and, desc, eq, getTableColumns, gt, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import { genreName } from '$lib/arib';
 import { SERVICE_TYPE_LABEL } from '$lib/format';
 import { parseSearchFields } from '$lib/search';
 import { config } from '$lib/server/config';
 import { contending, type Occupant, rivalsOf } from '$lib/server/conflict';
-import { database, now, queryAll, queryOne } from '$lib/server/db';
+import { now, orm } from '$lib/server/db';
 import { CURRENT_SERVICES } from '$lib/server/epg';
 import { cancel } from '$lib/server/reservations';
 import { applyRules, compile, haystack, matchesCompiled } from '$lib/server/rules';
 import { resolveConflicts, tunerCapacity } from '$lib/server/scheduler';
+import { programs, reservations, rules as ruleTable, services as serviceTable } from '$lib/server/schema';
 import { settings } from '$lib/server/settings';
-import type { Program, Rule, Service } from '$lib/types';
+import type { Rule } from '$lib/types';
 
 interface Row extends Rule {
     reservations: number;
@@ -23,7 +25,7 @@ interface Row extends Rule {
  * 書かない)。`state IN ('scheduled','conflict')` だけで数えていた頃は、
  * 録り終えた予約まで「押さえている」に入っていた
  */
-const PENDING = "(state IN ('scheduled', 'conflict') AND started_at IS NULL)";
+const PENDING = and(inArray(reservations.state, ['scheduled', 'conflict']), isNull(reservations.started_at));
 
 /**
  * 条件の読み取り口。**画面から来る道が2つある** — 「この条件で何が録れるか」は
@@ -161,17 +163,33 @@ export async function load({ url }) {
     // 掴む区間は前後マージンぶん延びる。スケジューラと同じ物差しで数える
     const margins = { start: config.startMargin, end: config.endMargin };
     // ?edit=<id> のときは、そのルールをフォームに読み込んで書き換えられるようにする
-    const editing = queryOne<Rule>('SELECT * FROM rules WHERE id = ?', Number(url.searchParams.get('edit')));
+    const editing = orm()
+        .select()
+        .from(ruleTable)
+        .where(eq(ruleTable.id, Number(url.searchParams.get('edit'))))
+        .get();
 
     /** まだ録っていない予約。重なりの判定と、条件から外れた予約を出すのに使う */
-    const pending = queryAll<Pending>(
-        `SELECT r.id, r.rule_id, r.program_id, r.name, r.service_id, r.start_at, r.end_at, r.state,
-                r.conflict_reason, s.name AS service_name, s.type AS type, s.channel AS channel
-         FROM reservations r
-         JOIN services s ON s.id = r.service_id
-         WHERE r.state IN ('scheduled', 'conflict') AND r.started_at IS NULL
-         ORDER BY r.start_at`,
-    );
+    const pending: Pending[] = orm()
+        .select({
+            id: reservations.id,
+            rule_id: reservations.rule_id,
+            program_id: reservations.program_id,
+            name: reservations.name,
+            service_id: reservations.service_id,
+            start_at: reservations.start_at,
+            end_at: reservations.end_at,
+            state: reservations.state,
+            conflict_reason: reservations.conflict_reason,
+            service_name: serviceTable.name,
+            type: serviceTable.type,
+            channel: serviceTable.channel,
+        })
+        .from(reservations)
+        .innerJoin(serviceTable, eq(serviceTable.id, reservations.service_id))
+        .where(PENDING)
+        .orderBy(reservations.start_at)
+        .all();
     const reserved = new Map(pending.map((row) => [row.program_id, row]));
 
     /*
@@ -184,15 +202,18 @@ export async function load({ url }) {
     const conditions = conditionsFrom(url.searchParams) ?? editing ?? null;
     let preview: { total: number; programs: PreviewRow[]; conflicts: number } | null = null;
     if (conditions !== null && url.searchParams.size > 0) {
-        const all = queryAll<
-            Program & { service_type: string; service_name: string; service_channel: string }
-        >(
-            `SELECT p.*, s.type AS service_type, s.name AS service_name, s.channel AS service_channel
-             FROM programs p
-             JOIN services s ON s.id = p.service_id
-             WHERE p.start_at > ? ORDER BY p.start_at`,
-            now(),
-        );
+        const all = orm()
+            .select({
+                ...getTableColumns(programs),
+                service_type: serviceTable.type,
+                service_name: serviceTable.name,
+                service_channel: serviceTable.channel,
+            })
+            .from(programs)
+            .innerJoin(serviceTable, eq(serviceTable.id, programs.service_id))
+            .where(gt(programs.start_at, now()))
+            .orderBy(programs.start_at)
+            .all();
         // 条件のほどきは1回だけ。番組ごとにやり直すと、番組の数だけ JSON を読むことになる
         const compiled = compile(conditions);
         const hits = all.filter((program) =>
@@ -321,19 +342,22 @@ export async function load({ url }) {
      * この列を見るのは「このルールがいま何を押さえているか」を知りたいときなので、
      * 履歴は数えない
      */
-    const rules = database()
-        .prepare(
-            `SELECT r.*, (
-                 SELECT COUNT(*) FROM reservations
-                 WHERE rule_id = r.id AND ${PENDING}
-             ) AS reservations
-             FROM rules r ORDER BY r.id DESC`,
-        )
-        .all() as Row[];
+    const rules: Row[] = orm()
+        .select({
+            ...getTableColumns(ruleTable),
+            reservations: sql<number>`(SELECT COUNT(*) FROM ${reservations}
+                 WHERE ${reservations.rule_id} = ${ruleTable.id} AND ${PENDING})`.mapWith(Number),
+        })
+        .from(ruleTable)
+        .orderBy(desc(ruleTable.id))
+        .all();
     // 取り残しの局は選ばせない (CURRENT_SERVICES)。もう録れない局が並ぶだけ
-    const services = database()
-        .prepare(`SELECT * FROM services WHERE ${CURRENT_SERVICES} ORDER BY type, channel`)
-        .all() as Service[];
+    const services = orm()
+        .select()
+        .from(serviceTable)
+        .where(sql.raw(CURRENT_SERVICES))
+        .orderBy(serviceTable.type, serviceTable.channel)
+        .all();
     // フォームの初期値は preview と同じものを使う。別々に組み立てると、
     // 画面に出ている結果と保存されるものがズレる
     return { rules, services, editing: editing ?? null, seed: conditions, preview, defaults };
@@ -363,7 +387,7 @@ function rulePriority(fields: Fields): number {
 function ruleName(conditions: Conditions): string {
     if (conditions.keyword !== '') return conditions.keyword;
 
-    const services = queryAll<Service>('SELECT * FROM services');
+    const services = orm().select().from(serviceTable).all();
     const parts: string[] = [];
     if (conditions.genres !== null) {
         parts.push(...(JSON.parse(conditions.genres) as string[]).map(genreName));
@@ -409,18 +433,21 @@ async function reapply(rule?: number): Promise<number> {
 /** 条件が空だと全番組にマッチしてディスクを埋めるので作らせない */
 const EMPTY_RULE = 'キーワード・チャンネル・ジャンルのどれかは指定してください';
 
-/** create と update で並びが同じ8つ。SQL の `?` の順とここが対 */
-function ruleParams(conditions: ReturnType<typeof conditionsOf>, form: FormData) {
-    return [
-        ruleName(conditions),
-        conditions.keyword,
-        conditions.ignoreKeyword,
-        conditions.searchFields,
-        conditions.serviceIds,
-        conditions.serviceTypes,
-        conditions.genres,
-        rulePriority(form),
-    ] as const;
+/**
+ * create と update で同じ8つ。**焼き方は書かない** — エンコードもCMも全体設定で、
+ * 焼くときに読む
+ */
+function ruleValues(conditions: ReturnType<typeof conditionsOf>, form: FormData) {
+    return {
+        name: ruleName(conditions),
+        keyword: conditions.keyword,
+        ignore_keyword: conditions.ignoreKeyword,
+        search_fields: conditions.searchFields,
+        service_ids: conditions.serviceIds,
+        service_types: conditions.serviceTypes,
+        genres: conditions.genres,
+        priority: rulePriority(form),
+    };
 }
 
 export const actions = {
@@ -429,17 +456,14 @@ export const actions = {
         const conditions = conditionsOf(form);
         if (conditions.empty) return fail(400, { message: EMPTY_RULE });
 
-        const created = database()
-            .prepare(
-                // 焼き方は書かない。エンコードもCMも全体設定で、焼くときに読む
-                `INSERT INTO rules (name, keyword, ignore_keyword, search_fields, service_ids, service_types,
-                                genres, enabled, priority, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
-            )
-            .run(...ruleParams(conditions, form), now());
+        const created = orm()
+            .insert(ruleTable)
+            .values({ ...ruleValues(conditions, form), enabled: 1, created_at: now() })
+            .returning({ id: ruleTable.id })
+            .get()!;
 
         // 足したルールは他の予約を外せないので、そのルールだけ当てれば足りる
-        await reapply(Number(created.lastInsertRowid));
+        await reapply(created.id);
         return { success: true };
     },
 
@@ -451,13 +475,7 @@ export const actions = {
         const conditions = conditionsOf(form);
         if (conditions.empty) return fail(400, { message: EMPTY_RULE });
 
-        database()
-            .prepare(
-                // 焼き方は触らない。エンコードもCMも全体設定で、焼くときに読む
-                `UPDATE rules SET name = ?, keyword = ?, ignore_keyword = ?, search_fields = ?, service_ids = ?,
-                 service_types = ?, genres = ?, priority = ? WHERE id = ?`,
-            )
-            .run(...ruleParams(conditions, form), id);
+        orm().update(ruleTable).set(ruleValues(conditions, form)).where(eq(ruleTable.id, id)).run();
 
         /*
          * 条件が変わったので、これから録るぶんは組み直す。
@@ -491,7 +509,11 @@ export const actions = {
         const form = await request.formData();
         const id = Number(form.get('id'));
         if (!Number.isFinite(id)) return fail(400, { message: 'ルールIDが不正です' });
-        database().prepare('UPDATE rules SET enabled = 1 - enabled WHERE id = ?').run(id);
+        orm()
+            .update(ruleTable)
+            .set({ enabled: sql`1 - ${ruleTable.enabled}` })
+            .where(eq(ruleTable.id, id))
+            .run();
         await reapply();
         return { success: true };
     },
@@ -511,17 +533,23 @@ export const actions = {
          * 見てから決める** — 消したのが「アニメ」でも、「無職転生」が残っていれば
          * その予約は生き続けるべき (`rules.applyRules` が付け替える)
          */
-        database()
-            .prepare(
-                `DELETE FROM reservations
-                  WHERE rule_id = ? AND started_at IS NULL AND state = 'canceled'`,
+        orm()
+            .delete(reservations)
+            .where(
+                and(
+                    eq(reservations.rule_id, id),
+                    isNull(reservations.started_at),
+                    eq(reservations.state, 'canceled'),
+                ),
             )
-            .run(id);
+            .run();
         // 録画中・録画済みのぶんは履歴として残すので、ルールとの紐付けだけ外す
-        database()
-            .prepare('UPDATE reservations SET rule_id = NULL WHERE rule_id = ? AND started_at IS NOT NULL')
-            .run(id);
-        database().prepare('DELETE FROM rules WHERE id = ?').run(id);
+        orm()
+            .update(reservations)
+            .set({ rule_id: null })
+            .where(and(eq(reservations.rule_id, id), isNotNull(reservations.started_at)))
+            .run();
+        orm().delete(ruleTable).where(eq(ruleTable.id, id)).run();
 
         // 引き取り手の無い予約はここで消える (猶予は効かない = 人が押した結果なので)
         const dropped = await reapply();

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,13 +1,15 @@
 import { basename } from 'node:path';
 import { fail } from '@sveltejs/kit';
+import { eq, sql } from 'drizzle-orm';
 import { HW_CODECS, HW_KINDS, type HwAllow, hwAllowed } from '$lib/hw';
 import { isCmMode } from '$lib/server/cm';
-import { database, now, queryAll, queryOne } from '$lib/server/db';
+import { now, orm } from '$lib/server/db';
 import { describeDevice, type HwEncode, hwEncode, probe } from '$lib/server/hwenc';
 import { available as migrateAvailable, source, start, status } from '$lib/server/migrate';
+import { webhooks } from '$lib/server/schema';
 import { normalizePostalCode, saveSettings, settings } from '$lib/server/settings';
 import { serializeTargets, targets, type VlcTarget } from '$lib/server/vlc';
-import { send, type Webhook } from '$lib/server/webhook';
+import { send } from '$lib/server/webhook';
 import type { VideoCodec } from '$lib/types';
 import { normalizeVlcHost } from '$lib/vlc-host';
 import { EVENTS } from '$lib/webhook-events';
@@ -38,7 +40,7 @@ export function load() {
         broadcast: { postalCode: current.postalCode, bmlNetwork: current.bmlNetwork },
         /** テレビの VLC の居場所。画面は名前+ホストの行として編集する */
         vlc: { targets: targets() },
-        webhooks: queryAll<Webhook>('SELECT * FROM webhooks ORDER BY id'),
+        webhooks: orm().select().from(webhooks).orderBy(webhooks.id).all(),
         events: EVENTS,
         migrate: {
             available: migrateAvailable(),
@@ -178,11 +180,11 @@ export const actions = {
         // 何も選ばなければ全部の通知を受け取る
         const events = form.getAll('events').map(String).filter(Boolean);
 
-        database()
-            // name は廃止したが、既存DBの列が NOT NULL のままなので空文字を入れる。
-            // CREATE TABLE IF NOT EXISTS では列定義が変わらないため
-            .prepare('INSERT INTO webhooks (name, url, events, enabled, created_at) VALUES (?, ?, ?, 1, ?)')
-            .run('', url, JSON.stringify(events), now());
+        // name は廃止したが、列は残してある (既定 '' なので入れなくてよい)
+        orm()
+            .insert(webhooks)
+            .values({ url, events: JSON.stringify(events), enabled: 1, created_at: now() })
+            .run();
         return { success: true, webhookAdded: true };
     },
 
@@ -190,7 +192,11 @@ export const actions = {
         const form = await request.formData();
         const id = Number(form.get('id'));
         if (!Number.isFinite(id)) return fail(400, { message: 'IDが不正です' });
-        database().prepare('UPDATE webhooks SET enabled = 1 - enabled WHERE id = ?').run(id);
+        orm()
+            .update(webhooks)
+            .set({ enabled: sql`1 - ${webhooks.enabled}` })
+            .where(eq(webhooks.id, id))
+            .run();
         return { success: true };
     },
 
@@ -198,14 +204,14 @@ export const actions = {
         const form = await request.formData();
         const id = Number(form.get('id'));
         if (!Number.isFinite(id)) return fail(400, { message: 'IDが不正です' });
-        database().prepare('DELETE FROM webhooks WHERE id = ?').run(id);
+        orm().delete(webhooks).where(eq(webhooks.id, id)).run();
         return { success: true };
     },
 
     testWebhook: async ({ request }) => {
         const form = await request.formData();
         const id = Number(form.get('id'));
-        const webhook = queryOne<Webhook>('SELECT * FROM webhooks WHERE id = ?', id);
+        const webhook = orm().select().from(webhooks).where(eq(webhooks.id, id)).get();
         if (webhook === undefined) return fail(400, { message: '通知先が見つかりません' });
 
         const status = await send(webhook, {

--- a/src/routes/tuners/+page.server.ts
+++ b/src/routes/tuners/+page.server.ts
@@ -1,10 +1,12 @@
 import { fail } from '@sveltejs/kit';
-import { database, queryAll, queryOne } from '$lib/server/db';
+import { and, count, eq, sql } from 'drizzle-orm';
+import { orm } from '$lib/server/db';
 import { CURRENT_SERVICES } from '$lib/server/epg';
 import { collectNow, collectState } from '$lib/server/epg-collect';
 import { stats as logoStats, sweepNow, sweepState } from '$lib/server/logo';
 import { forgetLogoData, learned, stats as learnStats, siblings, stations } from '$lib/server/logo-data';
 import { refresh, start, stop } from '$lib/server/scan';
+import { programs, recordings, services } from '$lib/server/schema';
 import { cardStatus } from '$lib/server/scramble';
 import { type AgentTuner, getTuners, putTuners, type TunerConfig, tunersDetected } from '$lib/server/tuner';
 import type { ChannelType } from '$lib/types';
@@ -40,10 +42,11 @@ interface TunerUser {
 function describe(use: string): string {
     const recording = use.match(/^rec (\d+)$/);
     if (recording !== null) {
-        const row = queryOne<{ name: string }>(
-            'SELECT name FROM recordings WHERE id = ?',
-            Number(recording[1]),
-        );
+        const row = orm()
+            .select({ name: recordings.name })
+            .from(recordings)
+            .where(eq(recordings.id, Number(recording[1])))
+            .get();
         return row === undefined ? '録画' : `録画: ${row.name}`;
     }
 
@@ -90,22 +93,22 @@ interface Coverage {
  * 前の回の行は残る (録画や過去の予約が辿れなくなるので消せない)。
  */
 function coverage(): Coverage[] {
-    const rows = queryAll<{
-        id: number;
-        name: string;
-        type: ChannelType;
-        channel: string;
-        programs: number;
-        until: number;
-    }>(`
-        SELECT s.id, s.name, s.type, s.channel,
-               COUNT(p.id) AS programs, COALESCE(MAX(p.end_at), 0) AS until
-          FROM services s
-          LEFT JOIN programs p ON p.service_id = s.id
-         WHERE s.updated_at >= (SELECT MAX(updated_at) FROM services)
-         GROUP BY s.id
-         ORDER BY s.service_id
-    `);
+    const rows = orm()
+        .select({
+            id: services.id,
+            name: services.name,
+            type: services.type,
+            channel: services.channel,
+            programs: count(programs.id),
+            until: sql`COALESCE(MAX(${programs.end_at}), 0)`.mapWith(Number),
+        })
+        .from(services)
+        .leftJoin(programs, eq(programs.service_id, services.id))
+        // 取り残しの局は出さない (CURRENT_SERVICES と同じ。番組表と JOIN するので列を名指しする)
+        .where(sql`${services.updated_at} >= (SELECT MAX(${services.updated_at}) FROM ${services})`)
+        .groupBy(services.id)
+        .orderBy(services.service_id)
+        .all();
 
     const order: Record<string, number> = { GR: 0, BS: 1, CS: 2 };
     const channels = new Map<string, Coverage>();
@@ -183,23 +186,23 @@ export async function load() {
  * 「6 / 46 局」と出ている下に 125 局が並ぶ。
  */
 function cmLogoState(): CmLogo[] {
-    const services = queryAll<{
-        id: number;
-        network_id: number;
-        name: string;
-        logo_area: string | null;
-        recording_id: number | null;
-    }>(`
-        SELECT s.id, s.network_id, s.name, s.logo_area,
-               (SELECT r.id FROM recordings r
-                 WHERE r.service_id = s.id AND r.deleted_at IS NULL
-                 ORDER BY r.id DESC LIMIT 1) AS recording_id
-          FROM services s
-         WHERE s.service_type = 1 AND ${CURRENT_SERVICES}
-         ORDER BY s.remote_control_key IS NULL, s.remote_control_key, s.id
-    `);
+    const rows = orm()
+        .select({
+            id: services.id,
+            network_id: services.network_id,
+            name: services.name,
+            logo_area: services.logo_area,
+            /** その局の、いちばん新しい現存の録画 (枠を囲うのに絵を出す) */
+            recording_id: sql<number | null>`(SELECT r.id FROM recordings r
+                 WHERE r.service_id = ${services.id} AND r.deleted_at IS NULL
+                 ORDER BY r.id DESC LIMIT 1)`,
+        })
+        .from(services)
+        .where(and(eq(services.service_type, 1), sql.raw(CURRENT_SERVICES)))
+        .orderBy(sql`${services.remote_control_key} IS NULL`, services.remote_control_key, services.id)
+        .all();
     // 同じ絵を映しているサブチャンネルの枠は束ねる (実機で「TOKYO MX1」が2つ並んでいた)
-    return stations(services).map((service) => ({ ...service, learned: learned(service.id) }));
+    return stations(rows).map((service) => ({ ...service, learned: learned(service.id) }));
 }
 
 export const actions = {
@@ -224,9 +227,11 @@ export const actions = {
         }
         // 同じ絵を映しているサブチャンネルの枠にも同じことをする (`logo-data.stations`)
         for (const id of [serviceId, ...siblings(serviceId)]) {
-            database()
-                .prepare('UPDATE services SET logo_area = ?, logo_area_auto = 0 WHERE id = ?')
-                .run(area, id);
+            orm()
+                .update(services)
+                .set({ logo_area: area, logo_area_auto: 0 })
+                .where(eq(services.id, id))
+                .run();
             forgetLogoData(id);
         }
         return {
@@ -261,9 +266,11 @@ export const actions = {
         const serviceId = Number(form.get('serviceId'));
         if (!Number.isFinite(serviceId)) return fail(400, { message: '局IDが不正です' });
         for (const id of [serviceId, ...siblings(serviceId)]) {
-            database()
-                .prepare('UPDATE services SET logo_area = NULL, logo_area_auto = 0 WHERE id = ?')
-                .run(id);
+            orm()
+                .update(services)
+                .set({ logo_area: null, logo_area_auto: 0 })
+                .where(eq(services.id, id))
+                .run();
             // 教えた枠で覚えたものが残っていると、自動に戻しても効かない
             forgetLogoData(id);
         }


### PR DESCRIPTION
## なにを

#37 の続きです。残っていた生 SQL (130 箇所ほど) を `orm()` の型付きクエリに置き換えました。

- サーバ側: encoder / recorder / epg / files / scheduler / live / migrate / logo
- 画面側: rules / tuners / settings / guide / dashboard と API (programs / health)

## どう直したか

- **変えた行数が要るところは `affected()`** (`db.ts` に追加)。bun の `.run()` は行数を返しているのに drizzle の型の上では void になるので、組み立てた SQL を生の接続で流して行数を取る。まとめて消す/直すところ (履歴の片付け・録り逃しの整理など) で使う。**1 行の取り合い (claim)** は `.returning().get()` で足りるのでそちら
- `INSERT OR IGNORE` は `.onConflictDoNothing().returning().get()` にして、作れたときだけ行が返る形に (rules.applyRules)
- `UPDATE … SET x = x + 1` / `COALESCE(...)` は `sql` テンプレートで列を名指し (`sql\`${t.attempts} + 1\``)
- 番組表の集約 (局ごとの件数・最新の end_at) と、局ごとの直近の録画 (相関サブクエリ) は `count()` / `sql<number>` で組んだ。LEFT JOIN で `updated_at` が両側にあるので、CURRENT_SERVICES は列を名指しした版を書いている (tuners の coverage)

## 残した生 SQL (意図的)

- `RESERVATION_STATE` の CASE を挟む一覧: dashboard の予約/録画/録り逃し、guide のグリッド、watch の 1 行。drizzle で書けなくはないが、raw の CASE を挟むだけで読みにくくなる
- `UPDATE reservations … FROM programs` (epg の syncReservationTimes)

`db.ts` の `queryOne` / `queryAll` はその 5 箇所のために残しています。

## 確かめたこと

- `bun run lint` / `bun run check` 通過
- 単体テスト 793 本通過
- e2e 145 本通過 (3 本が再試行で成功)。再試行になった 22-watch を単体で回し直すと、失敗の中身は `browser.newContext: browser has been closed` で、アプリに触る前に Playwright のブラウザ自体が落ちたものでした (手元の WSL の資源絡み)。単体では通ります

🤖 Generated with [Claude Code](https://claude.com/claude-code)
