### PR TITLE
refactor: 省ける項目と index signature の読み方を厳しくする

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -33,6 +33,11 @@
             "style": {
                 "noNonNullAssertion": "off"
             },
+            "complexity": {
+                // tsconfig の noPropertyAccessFromIndexSignature と逆向き。
+                // `process.env['X']` のように、型が index signature のものは [] で読む
+                "useLiteralKeys": "off"
+            },
             "a11y": {
                 // 字幕は放送が絵で送ってくる。canvas に重ねるので <track> に渡せるものが無い
                 "useMediaCaption": "off",

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -11,7 +11,8 @@ import { begin, finish } from './busy.svelte';
  * 二度押し・三度押しできてしまう。
  */
 export function submitting(node: HTMLFormElement, submit?: SubmitFunction) {
-    return enhance(node, (input) => {
+    // 型引数は `SubmitFunction` の既定に揃える。省くと `| undefined` 側に推論され、after に渡せない
+    return enhance<Record<string, unknown>, Record<string, unknown>>(node, (input) => {
         const buttons = [...node.querySelectorAll('button')];
         begin();
         node.setAttribute('aria-busy', 'true');

--- a/src/lib/arib.ts
+++ b/src/lib/arib.ts
@@ -340,15 +340,16 @@ export function audioTracks(audios: Audio[]): AudioTrack[] {
         const head = many && !named ? `音声${stream + 1} ` : '';
         const langs = (audio.langs ?? []).map((lang) => LANGUAGE[lang] ?? lang);
         const of = (index: number) => (langs[index] === undefined ? '' : ` (${langs[index]})`);
-        const main = audio.main;
+        // 放送が言っていなければ付けない (undefined を書き込まない)
+        const main = audio.main === undefined ? {} : { main: audio.main };
 
         if (audio.componentType === DUAL_MONO) {
             // 左右に分かれているので、名前ではなくどちら側かで呼ぶ
             const index = many ? `音声${stream + 1} ` : '';
             tracks.push(
-                { id: `${stream}:main`, stream, side: 'main', label: `${index}主音声${of(0)}`, main },
-                { id: `${stream}:sub`, stream, side: 'sub', label: `${index}副音声${of(1)}`, main },
-                { id: `${stream}:both`, stream, side: 'both', label: `${index}主+副`, main },
+                { id: `${stream}:main`, stream, side: 'main', label: `${index}主音声${of(0)}`, ...main },
+                { id: `${stream}:sub`, stream, side: 'sub', label: `${index}副音声${of(1)}`, ...main },
+                { id: `${stream}:both`, stream, side: 'both', label: `${index}主+副`, ...main },
             );
         } else {
             tracks.push({
@@ -356,7 +357,7 @@ export function audioTracks(audios: Audio[]): AudioTrack[] {
                 stream,
                 side: 'both',
                 label: `${head}${audioLabel(audio)}`,
-                main,
+                ...main,
             });
         }
     });

--- a/src/lib/components/ProgramDetail.svelte
+++ b/src/lib/components/ProgramDetail.svelte
@@ -27,7 +27,7 @@
         cmNote?: string | null;
         /** 焼いたもののコマ数。録画から開いたときだけ入る (ProgramFacts へ素通し) */
         fps?: number | null;
-        actions?: Snippet;
+        actions?: Snippet | undefined;
     } = $props();
 </script>
 

--- a/src/lib/live-player.svelte.ts
+++ b/src/lib/live-player.svelte.ts
@@ -1259,7 +1259,7 @@ export function livePlayer() {
                 type: 'chase',
                 recordingId: chase.recordingId,
                 at: chase.base,
-                audio: audio === '' ? undefined : audio,
+                ...(audio === '' ? {} : { audio }),
                 codec,
                 caption: captionTrack,
             };

--- a/src/lib/offline.svelte.ts
+++ b/src/lib/offline.svelte.ts
@@ -314,7 +314,7 @@ export async function saveOffline(rec: SaveTarget): Promise<void> {
             // downloadTotal は実測の合計 + 2% (転送の揺れぶん。超えたら打ち切られる)
             const running = await reg.backgroundFetch.fetch(fetchId(rec.id, source, attempt), urls, {
                 title: `denpa: ${rec.name}`,
-                downloadTotal: total === null ? undefined : Math.round(total * 1.02),
+                ...(total === null ? {} : { downloadTotal: Math.round(total * 1.02) }),
             });
             watchProgress(running);
             return;

--- a/src/lib/server/encoder.ts
+++ b/src/lib/server/encoder.ts
@@ -321,7 +321,7 @@ interface EncodeOptions {
      * `hwenc.hwChain` が決めていて、runJob がその順に渡す。落ちたら次、
      * 最後はソフトウェア (undefined)
      */
-    hardware?: HwWay;
+    hardware?: HwWay | undefined;
 }
 
 /**
@@ -672,7 +672,7 @@ export function inputProgress(inputBytes: number) {
          * 出すと、そこで止まって見える (失敗して頭からやり直す時は特に、
          * 100% → 0% と動いて二度おかしく見えた)
          */
-        const percent = block.progress === 'end' ? 1 : Math.min(Math.max(prev, fraction), 0.99);
+        const percent = block['progress'] === 'end' ? 1 : Math.min(Math.max(prev, fraction), 0.99);
 
         let etaMs: number | null = null;
         if (readable) {
@@ -688,12 +688,12 @@ export function inputProgress(inputBytes: number) {
         }
 
         const mb = (bytes: number) => (bytes / 1024 / 1024).toFixed(0);
-        const sizeMb = (parseInt(block.total_size, 10) / 1024 / 1024).toFixed(1);
-        const rateMbps = (parseFloat(block.bitrate) / 1000).toFixed(2);
+        const sizeMb = (parseInt(block['total_size'], 10) / 1024 / 1024).toFixed(1);
+        const rateMbps = (parseFloat(block['bitrate']) / 1000).toFixed(2);
         return {
             percent,
             etaMs,
-            log: `input: ${readable ? `${mb(pos)}/${mb(inputBytes)}MB` : '測れず'}, speed: ${block.speed}, size: ${sizeMb}MB, rate: ${rateMbps}Mbps, drop: ${block.drop_frames}`,
+            log: `input: ${readable ? `${mb(pos)}/${mb(inputBytes)}MB` : '測れず'}, speed: ${block['speed']}, size: ${sizeMb}MB, rate: ${rateMbps}Mbps, drop: ${block['drop_frames']}`,
         };
     };
 }
@@ -813,9 +813,9 @@ async function runFfmpeg(
                 const eq = line.indexOf('=');
                 if (eq === -1) continue;
                 block[line.slice(0, eq)] = line.slice(eq + 1).trim();
-                if (block.progress === undefined) continue;
+                if (block['progress'] === undefined) continue;
 
-                const at = Number(block.out_time_us);
+                const at = Number(block['out_time_us']);
                 if (Number.isFinite(at) && at > 0) outTimeUs = at;
 
                 if (inputFd === null) inputFd = findInputFd(proc.pid, inputPath);

--- a/src/lib/server/live.ts
+++ b/src/lib/server/live.ts
@@ -1198,6 +1198,78 @@ export function warm(
     timer.unref?.();
 }
 
+/** 画面からの指示 (`$lib/live` の `Command`) を、省かれたところを既定で埋めて読んだもの */
+type Asked =
+    | { type: 'data'; on: boolean }
+    | {
+          type: 'tune';
+          channelType: string;
+          channel: string;
+          serviceId: number;
+          /** 省かれていれば主音声 (`nowPlaying` が決める) */
+          audio: string | undefined;
+          codec: LiveCodec;
+          caption: number;
+      }
+    | ChaseAsked;
+
+type ChaseAsked = {
+    type: 'chase';
+    /** 整数でないものもここまでは来る。断るのは `openChase` (見ている人に理由を返すため) */
+    recordingId: number;
+    at: number;
+    audio: string | undefined;
+    codec: LiveCodec;
+    caption: number;
+};
+
+/**
+ * 画面から来た JSON を読む。**画面から来る値をそのまま信じない** — 知らない形の
+ * 焼き方は H.264 に、数でないものは 0 に落とす。読めないもの (知らない type、
+ * 局の名指しが無い tune) は null で、黙って捨てる。
+ *
+ * 読むのをここ1箇所にしてある。選局と追っかけで別々に読んでいた頃は、字幕の
+ * 取り決めのように**両方に足すもの**が片方だけになりやすかった
+ */
+function parseCommand(message: Record<string, unknown>): Asked | null {
+    const audio = typeof message['audio'] === 'string' ? message['audio'] : undefined;
+    const codec: LiveCodec = message['codec'] === 'av1' ? 'av1' : 'h264';
+    // **字幕も映像と同じ ffmpeg**。選び直すと焼き直しになる (`encodeArgs`)
+    const caption = Number.isInteger(message['caption']) ? Math.max(0, Number(message['caption'])) : 0;
+    switch (message['type']) {
+        case 'data':
+            return { type: 'data', on: message['on'] === true };
+        case 'chase': {
+            const at = Number(message['at']);
+            return {
+                type: 'chase',
+                recordingId: Number(message['recordingId']),
+                at: Number.isFinite(at) ? Math.max(0, at) : 0,
+                audio,
+                codec,
+                caption,
+            };
+        }
+        case 'tune': {
+            const channelType = message['channelType'];
+            const channel = message['channel'];
+            if (typeof channelType !== 'string' || channelType === '') return null;
+            if (typeof channel !== 'string' || channel === '') return null;
+            return {
+                type: 'tune',
+                channelType,
+                channel,
+                serviceId: Number(message['serviceId']),
+                audio,
+                codec,
+                caption,
+            };
+        }
+        default:
+            return null;
+    }
+}
+
 /**
  * 1本ぶんの受け持ち。**繋いでいる間だけチューナーを掴む。**
  *
@@ -1217,34 +1289,27 @@ export function attend(connection: Connection): void {
     };
 
     connection.onmessage = (message) => {
+        const asked = parseCommand(message);
+        if (asked === null) return;
         /*
          * **データ放送は頼まれてから解く** (`Session.wantData`)。選局の指示とは
          * 別に受ける — 押すたびに焼き直していたら絵が途切れる
          */
-        if (message.type === 'data') {
-            current?.wantData(viewer, message.on === true);
+        if (asked.type === 'data') {
+            current?.wantData(viewer, asked.on);
             return;
         }
         /*
          * **追っかけ再生** (issue #16)。シークも同じ指示の送り直しで、
          * そのたびに焼き直す (ライブの選局し直しと同じ流儀)
          */
-        if (message.type === 'chase') {
+        if (asked.type === 'chase') {
             leave();
             viewer.ready = false;
-            current = openChase(message, viewer, connection);
+            current = openChase(asked, viewer, connection);
             return;
         }
-        if (message.type !== 'tune') return;
-        const channelType = typeof message.channelType === 'string' ? message.channelType : '';
-        const channel = typeof message.channel === 'string' ? message.channel : '';
-        const serviceId = Number(message.serviceId);
-        const audio = typeof message.audio === 'string' ? message.audio : undefined;
-        // 知らない形を頼まれたら H.264。**画面から来る値をそのまま信じない**
-        const codec: LiveCodec = message.codec === 'av1' ? 'av1' : 'h264';
-        // **字幕も映像と同じ ffmpeg**。選び直すと焼き直しになる (`encodeArgs`)
-        const caption = Number.isInteger(message.caption) ? Math.max(0, Number(message.caption)) : 0;
-        if (channelType === '' || channel === '') return;
+        const { channelType, channel, serviceId, audio, codec, caption } = asked;
 
         const now = nowPlaying(serviceId, audio);
 
@@ -1324,7 +1389,7 @@ export function attend(connection: Connection): void {
  * シークはバイト比例で当たりを付ける (`chasePlan`)。生TSに時間の索引は無いが、
  * 放送TSはレートがほぼ一定なので大きくは外れない。
  */
-function openChase(message: Record<string, unknown>, viewer: Viewer, connection: Connection): Session | null {
+function openChase(asked: ChaseAsked, viewer: Viewer, connection: Connection): Session | null {
     const tell = (notice: Notice) =>
         connection.send(CHANNEL.control, 0n, new TextEncoder().encode(JSON.stringify(notice)));
     const refuse = (text: string): null => {
@@ -1332,12 +1397,7 @@ function openChase(message: Record<string, unknown>, viewer: Viewer, connection:
         return null;
     };
 
-    const recordingId = Number(message.recordingId);
-    const at = Number.isFinite(Number(message.at)) ? Math.max(0, Number(message.at)) : 0;
-    const wanted = typeof message.audio === 'string' ? message.audio : undefined;
-    // 知らない形を頼まれたら H.264。**画面から来る値をそのまま信じない**
-    const codec: LiveCodec = message.codec === 'av1' ? 'av1' : 'h264';
-    const caption = Number.isInteger(message.caption) ? Math.max(0, Number(message.caption)) : 0;
+    const { recordingId, at, audio: wanted, codec, caption } = asked;
     if (!Number.isInteger(recordingId)) return refuse('録画が見つかりません');
 
     const rec = orm().select().from(recordings).where(eq(recordings.id, recordingId)).get();

--- a/src/lib/server/oidc.test.ts
+++ b/src/lib/server/oidc.test.ts
@@ -197,9 +197,8 @@ describe('通していい人か', () => {
 
 describe('画面に出す名前', () => {
     test('name が無ければ別の名乗りを使う', () => {
-        expect(displayName({ ...base, name: undefined, preferred_username: 'ruk@example' })).toBe(
-            'ruk@example',
-        );
-        expect(displayName({ ...base, name: undefined })).toBe('');
+        const { name: _name, ...nameless } = base;
+        expect(displayName({ ...nameless, preferred_username: 'ruk@example' })).toBe('ruk@example');
+        expect(displayName(nameless)).toBe('');
     });
 });

--- a/src/lib/server/oidc.ts
+++ b/src/lib/server/oidc.ts
@@ -285,7 +285,7 @@ export function allowed(claims: Claims): { ok: true } | { ok: false; reason: str
          * `groups` の代わりに `_claim_names` を入れて「Graph を叩いて取れ」と言う。
          * 黙って弾くと「なぜか自分だけ入れない」になるので、理由を出す
          */
-        const overflow = claims._claim_names?.groups !== undefined;
+        const overflow = claims._claim_names?.['groups'] !== undefined;
         return {
             ok: false,
             reason: overflow

--- a/src/lib/server/scramble.ts
+++ b/src/lib/server/scramble.ts
@@ -136,7 +136,7 @@ export async function descramble(
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ input: from, output: to }),
-            signal,
+            signal: signal ?? null,
         });
         const body = (await res.json()) as { ok?: boolean; error?: string };
         if (!res.ok || body.ok !== true) {

--- a/src/lib/server/stream.ts
+++ b/src/lib/server/stream.ts
@@ -66,7 +66,12 @@ export interface RunResult {
  */
 export async function run(
     argv: string[],
-    options: { signal?: AbortSignal; timeoutMs?: number; stdout?: boolean; stderr?: boolean } = {},
+    options: {
+        signal?: AbortSignal | undefined;
+        timeoutMs?: number;
+        stdout?: boolean;
+        stderr?: boolean;
+    } = {},
 ): Promise<RunResult> {
     let proc: Bun.Subprocess<'ignore', 'pipe' | 'ignore', 'pipe' | 'ignore'>;
     try {

--- a/src/lib/ts/bml.ts
+++ b/src/lib/ts/bml.ts
@@ -159,7 +159,13 @@ function parsePmt(section: Uint8Array): ComponentPMT[] {
             }
         }
         if (componentId === undefined) continue;
-        components.push({ componentId, pid, streamType, dataComponentId, bxmlInfo });
+        components.push({
+            componentId,
+            pid,
+            streamType,
+            ...(dataComponentId === undefined ? {} : { dataComponentId }),
+            ...(bxmlInfo === undefined ? {} : { bxmlInfo }),
+        });
     }
     return components;
 }
@@ -367,7 +373,7 @@ export class BmlDecoder {
                 size: module.moduleSize,
             })),
             dataEventId,
-            returnToEntryFlag: dii.returnToEntry ?? undefined,
+            ...(dii.returnToEntry === null ? {} : { returnToEntryFlag: dii.returnToEntry }),
         });
     }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,13 +40,13 @@
     function apply() {
         const dark =
             mode === 'dark' || (mode === 'system' && matchMedia('(prefers-color-scheme: dark)').matches);
-        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
-        document.documentElement.dataset.themeMode = mode;
+        document.documentElement.dataset['theme'] = dark ? 'dark' : 'light';
+        document.documentElement.dataset['themeMode'] = mode;
     }
 
     onMount(() => {
         hydrated = true;
-        mode = (document.documentElement.dataset.themeMode as 'system' | 'light' | 'dark') ?? 'system';
+        mode = (document.documentElement.dataset['themeMode'] as 'system' | 'light' | 'dark') ?? 'system';
 
         // 端末側の設定が変わったら、system のときだけ追従する
         const media = matchMedia('(prefers-color-scheme: dark)');

--- a/src/routes/live/+page.server.ts
+++ b/src/routes/live/+page.server.ts
@@ -51,14 +51,14 @@ function remembered(
     try {
         const saved = JSON.parse(raw) as Record<string, unknown>;
         const found = channels.find(
-            (channel) => channel.type === saved.channelType && channel.channel === saved.channel,
+            (channel) => channel.type === saved['channelType'] && channel.channel === saved['channel'],
         );
         if (found === undefined) return null;
         return {
             channel: found,
-            audio: typeof saved.audio === 'string' ? saved.audio : undefined,
+            ...(typeof saved['audio'] === 'string' ? { audio: saved['audio'] } : {}),
             // 覚えていない形を渡さない。知らない値なら既定 (H.264) に落ちる
-            codec: saved.codec === 'av1' ? 'av1' : undefined,
+            ...(saved['codec'] === 'av1' ? { codec: 'av1' as const } : {}),
         };
     } catch {
         return null;
@@ -145,13 +145,13 @@ export function load({ url, cookies }) {
                   channel: target.channel,
                   serviceId: target.id,
                   // 音声の控えは、同じ局に戻ったときだけ活かす
-                  audio: saved?.audio,
+                  ...(saved?.audio === undefined ? {} : { audio: saved.audio }),
                   /*
                    * **焼き方は局が変わっても引き継ぐ。** 音声と違って番組の中身で
                    * 決まるものではなく、その端末で出るかどうかの話なので、
                    * 局を選び直すたびに H.264 へ戻されては困る
                    */
-                  codec: kept?.codec,
+                  ...(kept?.codec === undefined ? {} : { codec: kept.codec }),
               };
 
     /*

--- a/src/routes/live/+page.svelte
+++ b/src/routes/live/+page.svelte
@@ -170,7 +170,7 @@
             service_name: channel.name,
             start_at: channel.now.startAt,
             end_at: channel.now.endAt,
-            description: channel.now.description ?? undefined,
+            description: channel.now.description ?? '',
         });
     }
 

--- a/tests/e2e/18-pwa.spec.ts
+++ b/tests/e2e/18-pwa.spec.ts
@@ -44,13 +44,13 @@ test.describe('PWA', () => {
             const res = await request.get(path);
             expect(res.status(), path).toBe(200);
             expect(res.headers()['cache-control'], path).toBe('no-cache');
-            expect(res.headers().etag, path).toBeTruthy();
+            expect(res.headers()['etag'], path).toBeTruthy();
         }
 
         // 指紋が付いているものは、変わっていなければ中身を流さない
         const first = await request.get('/');
         const again = await request.get('/', {
-            headers: { 'if-none-match': first.headers().etag },
+            headers: { 'if-none-match': first.headers()['etag'] },
         });
         expect(again.status()).toBe(304);
 

--- a/tests/e2e/22-oidc.spec.ts
+++ b/tests/e2e/22-oidc.spec.ts
@@ -49,7 +49,7 @@ function client(oidc: OidcStack, { xff = OUTSIDE, host = 'denpa.test' } = {}) {
             'x-forwarded-for': xff,
             ...((init.headers as Record<string, string>) ?? {}),
         };
-        if (jar.size > 0) headers.cookie = [...jar].map(([k, v]) => `${k}=${v}`).join('; ');
+        if (jar.size > 0) headers['cookie'] = [...jar].map(([k, v]) => `${k}=${v}`).join('; ');
         const res = await fetch(`${oidc.appUrl}${path}`, { ...init, headers, redirect: 'manual' });
         for (const raw of res.headers.getSetCookie?.() ?? []) {
             const [pair] = raw.split(';');

--- a/tests/fake/agent.ts
+++ b/tests/fake/agent.ts
@@ -13,15 +13,15 @@ import { resolve } from 'node:path';
 import { broadcast, channels, DEFAULT_KNOBS, type Knobs, on } from './broadcast';
 import type { FakeService } from './services';
 
-const PORT = Number(process.env.FAKE_AGENT_PORT ?? 25252);
+const PORT = Number(process.env['FAKE_AGENT_PORT'] ?? 25252);
 /** denpa の置き場。本物では同じものをエージェント側にも見せてある */
 const ROOTS: Record<string, string> = {
-    recorded: resolve(process.env.RECORDED_DIR ?? '/recorded'),
-    library: resolve(process.env.LIBRARY_DIR ?? '/library'),
+    recorded: resolve(process.env['RECORDED_DIR'] ?? '/recorded'),
+    library: resolve(process.env['LIBRARY_DIR'] ?? '/library'),
 };
 
 /** テストから切り替えるつまみ。本物では `tune.ts` がファイル越しに読む */
-const knobs: Knobs = { ...DEFAULT_KNOBS, scrambled: process.env.FAKE_SCRAMBLED === '1' };
+const knobs: Knobs = { ...DEFAULT_KNOBS, scrambled: process.env['FAKE_SCRAMBLED'] === '1' };
 /** チューナーが塞がっている状態。取り合いの見え方を確かめる */
 let busyTuners = false;
 

--- a/tests/fake/broadcast.ts
+++ b/tests/fake/broadcast.ts
@@ -71,7 +71,7 @@ export interface Knobs {
 export const DEFAULT_KNOBS: Knobs = { scrambled: false, extendedMs: 0, noPresentFollowing: false };
 
 /** 1枠の本数。E2E では短くして「数秒後に始まる番組」を作る */
-const SLOTS = Number(process.env.FAKE_SLOTS ?? 60);
+const SLOTS = Number(process.env['FAKE_SLOTS'] ?? 60);
 
 export function programsFor(service: FakeService): SynthEvent[] {
     const slotMs = service.slotMs;

--- a/tests/fake/idp.ts
+++ b/tests/fake/idp.ts
@@ -8,8 +8,8 @@
  * **人は出てこない。** `authorize` に来たらその場でコードを発行して戻す。
  * 「誰が入るか」は `FAKE_IDP_GROUPS` で決める — 通す人と断る人の両方を試すため。
  */
-const PORT = Number(process.env.FAKE_IDP_PORT ?? 9876);
-const ISSUER = process.env.FAKE_IDP_ISSUER ?? `http://127.0.0.1:${PORT}`;
+const PORT = Number(process.env['FAKE_IDP_PORT'] ?? 9876);
+const ISSUER = process.env['FAKE_IDP_ISSUER'] ?? `http://127.0.0.1:${PORT}`;
 const KID = 'fake-key';
 
 const pair = await crypto.subtle.generateKey(
@@ -32,7 +32,7 @@ const b64 = (bytes: Uint8Array) =>
 const encode = (value: unknown) => b64(new TextEncoder().encode(JSON.stringify(value)));
 
 /** どのグループに居ることにするか。テストから差し替える */
-let groups = (process.env.FAKE_IDP_GROUPS ?? 'admins').split(',').filter(Boolean);
+let groups = (process.env['FAKE_IDP_GROUPS'] ?? 'admins').split(',').filter(Boolean);
 /** `groups` そのものを載せない。アプリ登録の設定漏れを再現する */
 let omitGroups = false;
 

--- a/tests/fake/tune.ts
+++ b/tests/fake/tune.ts
@@ -29,7 +29,7 @@ if (services.length === 0) {
     process.exit(1);
 }
 
-const CONTROL = process.env.FAKE_CONTROL;
+const CONTROL = process.env['FAKE_CONTROL'];
 
 function knobs(): Knobs {
     if (CONTROL === undefined) return DEFAULT_KNOBS;

--- a/tests/fake/webhook.ts
+++ b/tests/fake/webhook.ts
@@ -4,7 +4,7 @@
  * denpa が Webhook を投げる相手。テストで「何が届いたか」を確かめるためだけのもので、
  * Discord や Slack の Incoming Webhook の代わりに立てる。
  */
-const PORT = Number(process.env.FAKE_WEBHOOK_PORT ?? 8096);
+const PORT = Number(process.env['FAKE_WEBHOOK_PORT'] ?? 8096);
 
 const calls: Record<string, unknown>[] = [];
 

--- a/tests/stack.ts
+++ b/tests/stack.ts
@@ -77,7 +77,7 @@ function start(command: string[], env: Record<string, string>): Started {
     });
     let log = '';
     const keep = (chunk: Buffer) => {
-        if (process.env.DENPA_E2E_LOG === '1') process.stdout.write(chunk);
+        if (process.env['DENPA_E2E_LOG'] === '1') process.stdout.write(chunk);
         log += chunk.toString();
         // 落ちたときの手掛かりが欲しいだけなので、後ろだけ持つ
         if (log.length > 20_000) log = log.slice(-20_000);
@@ -380,7 +380,7 @@ export const test = base.extend<{ anonymous: Anonymous }, { stack: Stack }>({
         const context = await playwright.request.newContext({
             baseURL: stack.appUrl,
             extraHTTPHeaders: { Origin: stack.appUrl },
-            httpCredentials: httpCredentials ?? undefined,
+            ...(httpCredentials === undefined ? {} : { httpCredentials }),
         });
         await use(context);
         await context.dispose();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
         "sourceMap": true,
         "strict": true,
         "noImplicitOverride": true,
+        "exactOptionalPropertyTypes": true,
+        "noPropertyAccessFromIndexSignature": true,
         "moduleResolution": "bundler",
         "types": ["bun"]
     }


### PR DESCRIPTION
## 何を

tsconfig に `exactOptionalPropertyTypes` と `noPropertyAccessFromIndexSignature` を足し、出た 70 箇所を直しました (#41 の続き)。

### exactOptionalPropertyTypes (18 箇所)

「省いてよい (`x?: T`)」と「undefined を入れてよい」を分けます。

- **見つかった実害**: ライブの番組詳細 (`live/+page.svelte`) が `description: channel.now.description ?? undefined` を渡していて、`programDetail.open` の `{ description: '', ...seed }` が undefined で潰されていました。`?? ''` に直しています。
- undefined を入れる意味があるところは `| undefined` を明記: `EncodeOptions.hardware` (undefined = ソフトウェアで焼く)、`runProcess` の `signal`、`ProgramDetail` の `actions`。
- それ以外は条件付きの spread で省く (音声の `main`、BML の `bxmlInfo` / `returnToEntryFlag`、覚えた局の `audio` / `codec`、追っかけの `audio`、Background Fetch の `downloadTotal`、e2e の `httpCredentials`)。
- `fetch` の `signal` は `?? null` (RequestInit は `AbortSignal | null`)。
- `submitting` (use:enhance の代わり) は `enhance` の型引数を明示。省くと `| undefined` 側に推論されて `after` に渡せなくなります。

### noPropertyAccessFromIndexSignature (52 箇所)

型が index signature のもの (`process.env`、画面から来た JSON、ffmpeg の `-progress` の key=value、`dataset`) を `[]` で読ませます。biome の `useLiteralKeys` は逆向きなので切りました (biome.jsonc に理由あり)。

ついでに**ライブの WebSocket で画面から来る指示は `parseCommand` の1箇所で読む**形にしました。`attend` (選局) と `openChase` (追っかけ) が別々に `Record<string, unknown>` を読んでいたのを、型の付いた `Asked` を受けるようにしています。読み方は前と同じ (知らない codec は H.264、数でないものは 0、局の名指しが無い tune は捨てる)。

## 確かめたこと

- `biome check .` / `svelte-check` 0 エラー
- 単体 793 本
- e2e: live / oidc / pwa の 62 本を先に単独で通し、全体も回しています

## 次の候補

- JSON で持つ列 (`genres` / `audios` / `extended` / `service_ids`…) を `{ mode: 'json' }` で型付きに。画面側の `JSON.parse` を全部触るので別 PR
- `noUncheckedIndexedAccess` は +540 箇所なので相談してから

🤖 Generated with [Claude Code](https://claude.com/claude-code)
