### PR TITLE
refactor: 添字で読んだものを undefined かもしれないものとして扱う (noUncheckedIndexedAccess)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,22 @@ JSON で持つ列 (ジャンル・音声の構成・ルールの対象チャン�
 オブジェクトとして触るだけで `JSON.parse` は書かない。読み手は列ごとに書き、壊れた行は
 「持っていない」(空の並び・NULL) にする — 1行が読めないせいで一覧ごと出なくなるのは困るので。
 
+## 型の締め方
+
+`tsconfig.json` は `strict` に加えて `exactOptionalPropertyTypes` (省けるのと undefined を
+入れてよいのは別)、`noPropertyAccessFromIndexSignature` (index signature のものは `[]` で読む)、
+`noUncheckedIndexedAccess` (添字で読んだものは undefined かもしれない) を入れてある。
+
+`noUncheckedIndexedAccess` の書き分け:
+
+- **バイト列の読み** (`data[i]`、`src/lib/ts/` の TS/PSI/EIT/PGS の読み手) は、長さを確かめた
+  上で `data[i]!`。1 バイトごとに undefined を見ると読み手が二倍の長さになるだけで、長さの
+  確認が既にある。確認が無いところに `!` を足さない
+- **配列の先頭・regex の group・`split()` の結果** は undefined を見る (`?? ''`、
+  `const [a = NaN] = ...`、`if (x === undefined) return`)。`[0]!` にしてよいのは、その直前で
+  空でないことを確かめている (`atLeastOne` のような) 場合だけ
+- **試験** は `!` でよい。落ちれば試験が落ちる
+
 **マイグレーションを持つ前の DB** (1.7.x まで。`CREATE TABLE IF NOT EXISTS` を起動のたびに
 流して整えていた) には、最初のマイグレーション (baseline) を `IF NOT EXISTS` にしてあるので
 そのまま当たる。1.7.x を一度も起動していない古い DB は列が足りないことがあり、起動時に

--- a/src/lib/arib.test.ts
+++ b/src/lib/arib.test.ts
@@ -157,7 +157,7 @@ describe('audioTracks', () => {
         ]);
         expect(tracks).toHaveLength(4);
         expect(tracks.slice(1).every((track) => track.stream === 1)).toBe(true);
-        expect(tracks[1].label).toBe('音声2 主音声 (日本語)');
+        expect(tracks[1]!.label).toBe('音声2 主音声 (日本語)');
     });
 
     /*

--- a/src/lib/arib.ts
+++ b/src/lib/arib.ts
@@ -403,7 +403,8 @@ export function audioTitles(audios: Audio[], dualMono: boolean): string[] {
  * 主音声とは限らないので、言っているならそちらに従う。何も言っていなければ先頭
  */
 export function pickTrack(tracks: AudioTrack[], wanted: string | undefined): AudioTrack {
-    return tracks.find((track) => track.id === wanted) ?? tracks.find((track) => track.main) ?? tracks[0];
+    // `audioTracks` は1本も無くても「音声」を1つ返すので、先頭は必ずある
+    return tracks.find((track) => track.id === wanted) ?? tracks.find((track) => track.main) ?? tracks[0]!;
 }
 
 const VIDEO_TYPE: Record<string, string> = {

--- a/src/lib/components/LogoArea.svelte
+++ b/src/lib/components/LogoArea.svelte
@@ -191,7 +191,7 @@
             box = null;
             return;
         }
-        const [x, y, w, h] = current.split(',').map(Number);
+        const [x = NaN, y = NaN, w = NaN, h = NaN] = current.split(',').map(Number);
         if (![x, y, w, h].every(Number.isFinite)) return;
         box = { x: x * s.x, y: y * s.y, w: w * s.x, h: h * s.y };
     });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -257,8 +257,8 @@ const NO_GENRE = 'bg-base-200 hover:bg-base-300 border-base-300';
 
 /** `programs.genres` (大分類の番号の並び) から色を決める。先頭を代表とする */
 export function genreTint(genres: number[] | null): string {
-    if (genres === null || genres.length === 0) return NO_GENRE;
-    return GENRE_TINT[genres[0]] ?? NO_GENRE;
+    const first = genres?.[0];
+    return first === undefined ? NO_GENRE : (GENRE_TINT[first] ?? NO_GENRE);
 }
 
 export const CM_LABEL: Record<string, string> = {

--- a/src/lib/pgs.test.ts
+++ b/src/lib/pgs.test.ts
@@ -39,7 +39,7 @@ function segments(sup: Uint8Array): { type: number; pts: number; payload: Uint8A
         expect(sup[at + 1]).toBe(0x47);
         const length = view.getUint16(at + 11);
         out.push({
-            type: sup[at + 10],
+            type: sup[at + 10]!,
             pts: view.getUint32(at + 2),
             payload: sup.subarray(at + 13, at + 13 + length),
         });
@@ -82,7 +82,7 @@ describe('色の表', () => {
         // 同じ緑でも書く値が違う
         expect([...bt709]).not.toEqual([...bt601]);
         // 明るさは BT.709 のほうが緑を重く見る (0.7152 対 0.587)
-        expect(bt709[0]).toBeGreaterThan(bt601[0]);
+        expect(bt709[0]).toBeGreaterThan(bt601[0]!);
     });
 
     test('255色を超えたら近い色に寄せる', () => {
@@ -149,7 +149,7 @@ describe('.sup の組み立て', () => {
     test('時刻は 90kHz 刻み', () => {
         const parts = segments(writeSup([{ start: 1.5, end: 3, bitmap: sample }]));
         // 先頭の空を挟んだ次から本体
-        expect(parts[2].pts).toBe(135_000);
+        expect(parts[2]!.pts).toBe(135_000);
         expect(parts.at(-1)?.pts).toBe(270_000);
     });
 
@@ -159,13 +159,13 @@ describe('.sup の組み立て', () => {
          * 字幕全体が前へずれる (実機で1秒ずれた)
          */
         const parts = segments(writeSup([{ start: 1, end: 3, bitmap: sample }]));
-        expect(parts[0].pts).toBe(0);
-        expect(parts[0].type).toBe(0x16);
-        expect(parts[0].payload[10]).toBe(0); // 中身は無い
-        expect(parts[1].type).toBe(0x80);
+        expect(parts[0]!.pts).toBe(0);
+        expect(parts[0]!.type).toBe(0x16);
+        expect(parts[0]!.payload[10]).toBe(0); // 中身は無い
+        expect(parts[1]!.type).toBe(0x80);
 
         // 0秒から始まるなら要らない
-        expect(segments(writeSup([{ start: 0, end: 3, bitmap: sample }]))[0].payload[10]).toBe(1);
+        expect(segments(writeSup([{ start: 0, end: 3, bitmap: sample }]))[0]!.payload[10]).toBe(1);
     });
 
     test('窓は字幕のあるところだけ', () => {
@@ -180,18 +180,18 @@ describe('.sup の組み立て', () => {
 
     test('画面の大きさは絵の大きさから取る', () => {
         const parts = segments(writeSup([{ start: 0, end: 1, bitmap: sample }]));
-        const view = new DataView(parts[0].payload.buffer, parts[0].payload.byteOffset);
+        const view = new DataView(parts[0]!.payload.buffer, parts[0]!.payload.byteOffset);
         expect(view.getUint16(0)).toBe(1440);
         expect(view.getUint16(2)).toBe(1080);
         // 中身は1つで、位置は切り抜いたところ
-        expect(parts[0].payload[10]).toBe(1);
+        expect(parts[0]!.payload[10]).toBe(1);
         expect(view.getUint16(15)).toBe(100);
         expect(view.getUint16(17)).toBe(900);
     });
 
     test('消すほうは中身を持たない', () => {
         const parts = segments(writeSup([{ start: 0, end: 1, bitmap: sample }]));
-        const clear = parts[5];
+        const clear = parts[5]!;
         expect(clear.type).toBe(0x16);
         expect(clear.payload[10]).toBe(0);
         expect(clear.payload).toHaveLength(11);
@@ -200,7 +200,7 @@ describe('.sup の組み立て', () => {
     test('絵の長さには大きさのぶんも数える', () => {
         const parts = segments(writeSup([{ start: 0, end: 1, bitmap: sample }]));
         const ods = parts.find((p) => p.type === 0x15)!;
-        const declared = (ods.payload[4] << 16) | (ods.payload[5] << 8) | ods.payload[6];
+        const declared = (ods.payload[4]! << 16) | (ods.payload[5]! << 8) | ods.payload[6]!;
         // 宣言された長さ = 幅高さ(4バイト) + 走り書き
         expect(declared).toBe(ods.payload.length - 7);
     });
@@ -265,11 +265,11 @@ describe('.sup を読み戻す', () => {
         ]);
         const drawn = readSup(sup);
         expect(drawn).toHaveLength(2);
-        expect(drawn[0].start).toBeCloseTo(1.5, 3);
-        expect(drawn[0].end).toBeCloseTo(3.5, 3);
+        expect(drawn[0]!.start).toBeCloseTo(1.5, 3);
+        expect(drawn[0]!.end).toBeCloseTo(3.5, 3);
         expect(drawn[0]).toMatchObject({ x: 100, y: 900, width: 40, height: 20 });
-        expect(drawn[0].videoWidth).toBe(1920);
-        expect(drawn[0].videoHeight).toBe(1080);
+        expect(drawn[0]!.videoWidth).toBe(1920);
+        expect(drawn[0]!.videoHeight).toBe(1080);
         expect(drawn[1]).toMatchObject({ x: 300, y: 800, width: 10, height: 10 });
     });
 
@@ -282,8 +282,8 @@ describe('.sup を読み戻す', () => {
                 bitmap: bitmap(1920, 1080, { x: 10, y: 10, w: 4, h: 4, color: [255, 255, 0, 255] }),
             },
         ]);
-        const [first] = readSup(sup);
-        const [r, g, b, a] = pixels(first).subarray(0, 4);
+        const first = readSup(sup)[0]!;
+        const [r = 0, g = 0, b = 0, a = 0] = pixels(first).subarray(0, 4);
         expect(a).toBe(255);
         expect(Math.abs(r - 255)).toBeLessThanOrEqual(3);
         expect(Math.abs(g - 255)).toBeLessThanOrEqual(3);
@@ -299,7 +299,7 @@ describe('.sup を読み戻す', () => {
                 bitmap: bitmap(200, 100, { x: 10, y: 10, w: 4, h: 2, color: [255, 0, 0, 255] }),
             },
         ]);
-        const [first] = readSup(sup);
+        const first = readSup(sup)[0]!;
         // 切り抜かれているので、中は全部塗られている
         expect(first.width).toBe(4);
         expect(first.height).toBe(2);

--- a/src/lib/pgs.ts
+++ b/src/lib/pgs.ts
@@ -143,7 +143,8 @@ export function quantize(pixels: Uint8Array, bt709 = true): Palette {
     const count = new Map<number, number>();
     for (let i = 0; i < pixels.length; i += 4) {
         if (pixels[i + 3] === 0) continue;
-        const key = ((pixels[i] << 24) | (pixels[i + 1] << 16) | (pixels[i + 2] << 8) | pixels[i + 3]) >>> 0;
+        const key =
+            ((pixels[i]! << 24) | (pixels[i + 1]! << 16) | (pixels[i + 2]! << 8) | pixels[i + 3]!) >>> 0;
         count.set(key, (count.get(key) ?? 0) + 1);
     }
 
@@ -177,7 +178,7 @@ export function quantize(pixels: Uint8Array, bt709 = true): Palette {
         let best = TRANSPARENT;
         let distance = Number.POSITIVE_INFINITY;
         for (let i = 0; i < chosen.length; i++) {
-            const other = chosen[i];
+            const other = chosen[i]!;
             const dr = r - ((other >>> 24) & 0xff);
             const dg = g - ((other >>> 16) & 0xff);
             const db = b - ((other >>> 8) & 0xff);
@@ -197,7 +198,8 @@ export function quantize(pixels: Uint8Array, bt709 = true): Palette {
             indices[p] = TRANSPARENT;
             continue;
         }
-        const key = ((pixels[i] << 24) | (pixels[i + 1] << 16) | (pixels[i + 2] << 8) | pixels[i + 3]) >>> 0;
+        const key =
+            ((pixels[i]! << 24) | (pixels[i + 1]! << 16) | (pixels[i + 2]! << 8) | pixels[i + 3]!) >>> 0;
         const found = index.get(key);
         if (found !== undefined) {
             indices[p] = found;
@@ -225,7 +227,7 @@ export function rle(indices: Uint8Array, width: number, height: number): Uint8Ar
     for (let y = 0; y < height; y++) {
         let x = 0;
         while (x < width) {
-            const color = indices[y * width + x];
+            const color = indices[y * width + x]!;
             let run = 1;
             while (x + run < width && indices[y * width + x + run] === color) run++;
             x += run;
@@ -317,10 +319,10 @@ function pds(entries: Uint8Array): Uint8Array {
     out[1] = 0; // 版
     for (let i = 0; i < 256; i++) {
         out[2 + i * 5] = i;
-        out[2 + i * 5 + 1] = entries[i * 4];
-        out[2 + i * 5 + 2] = entries[i * 4 + 1];
-        out[2 + i * 5 + 3] = entries[i * 4 + 2];
-        out[2 + i * 5 + 4] = entries[i * 4 + 3];
+        out[2 + i * 5 + 1] = entries[i * 4]!;
+        out[2 + i * 5 + 2] = entries[i * 4 + 1]!;
+        out[2 + i * 5 + 3] = entries[i * 4 + 2]!;
+        out[2 + i * 5 + 4] = entries[i * 4 + 3]!;
     }
     return out;
 }
@@ -548,7 +550,7 @@ export function unrle(data: Uint8Array, width: number, height: number): Uint8Arr
     while (at < data.length && y < height) {
         const first = data[at++];
         if (first !== 0) {
-            if (x < width) out[y * width + x] = first;
+            if (x < width) out[y * width + x] = first!;
             x++;
             continue;
         }
@@ -562,9 +564,9 @@ export function unrle(data: Uint8Array, width: number, height: number): Uint8Arr
         const long = (second & 0x40) !== 0;
         const colored = (second & 0x80) !== 0;
         let run = second & 0x3f;
-        if (long) run = (run << 8) | data[at++];
+        if (long) run = (run << 8) | data[at++]!;
         const color = colored ? data[at++] : TRANSPARENT;
-        for (let i = 0; i < run && x < width; i++, x++) out[y * width + x] = color;
+        for (let i = 0; i < run && x < width; i++, x++) out[y * width + x] = color!;
     }
     return out;
 }
@@ -576,7 +578,7 @@ function* segments(bytes: Uint8Array): Generator<{ type: number; pts: number; bo
     while (at + 13 <= bytes.length) {
         if (bytes[at] !== 0x50 || bytes[at + 1] !== 0x47) return;
         const pts = view.getUint32(at + 2) / CLOCK;
-        const type = bytes[at + 10];
+        const type = bytes[at + 10]!;
         const length = view.getUint16(at + 11);
         if (at + 13 + length > bytes.length) return;
         yield { type, pts, body: bytes.subarray(at + 13, at + 13 + length) };
@@ -624,17 +626,17 @@ export function readSup(bytes: Uint8Array): Drawn[] {
         if (type === SEGMENT_PDS) {
             // 番号ごとに YCrCbA が5バイト。書いていない番号は透明のまま
             for (let at = 2; at + 5 <= body.length; at += 5) {
-                const slot = body[at];
-                palette[slot * 4] = body[at + 1];
-                palette[slot * 4 + 1] = body[at + 2];
-                palette[slot * 4 + 2] = body[at + 3];
-                palette[slot * 4 + 3] = body[at + 4];
+                const slot = body[at]!;
+                palette[slot * 4] = body[at + 1]!;
+                palette[slot * 4 + 1] = body[at + 2]!;
+                palette[slot * 4 + 2] = body[at + 3]!;
+                palette[slot * 4 + 3] = body[at + 4]!;
             }
             continue;
         }
 
         if (type === SEGMENT_ODS) {
-            const flags = body[3];
+            const flags = body[3]!;
             if ((flags & 0x80) !== 0) {
                 // 最初の節。ここにだけ大きさが付く
                 building = {
@@ -689,18 +691,18 @@ function paint(indices: Uint8Array, palette: Uint8Array, videoHeight: number): U
     const data = new Uint8Array(indices.length * 4);
     const cache = new Map<number, [number, number, number]>();
     for (let i = 0; i < indices.length; i++) {
-        const slot = indices[i];
+        const slot = indices[i]!;
         const alpha = palette[slot * 4 + 3];
         if (alpha === 0) continue;
         let rgb = cache.get(slot);
         if (rgb === undefined) {
-            rgb = fromYCrCb(palette[slot * 4], palette[slot * 4 + 1], palette[slot * 4 + 2], bt709);
+            rgb = fromYCrCb(palette[slot * 4]!, palette[slot * 4 + 1]!, palette[slot * 4 + 2]!, bt709);
             cache.set(slot, rgb);
         }
         data[i * 4] = rgb[0];
         data[i * 4 + 1] = rgb[1];
         data[i * 4 + 2] = rgb[2];
-        data[i * 4 + 3] = alpha;
+        data[i * 4 + 3] = alpha!;
     }
     return data;
 }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -130,7 +130,7 @@ function entries(): string[] {
 export function inNetwork(address: string, entry: string): boolean {
     // ::ffff:10.0.0.1 のような書き方で届くことがある
     const target = address.replace(/^::ffff:/i, '');
-    const [network, bits] = entry.split('/');
+    const [network = '', bits] = entry.split('/');
     const left = toIpv4(target);
     const right = toIpv4(network.replace(/^::ffff:/i, ''));
     if (left === null || right === null) return target === network;

--- a/src/lib/server/bml-network.ts
+++ b/src/lib/server/bml-network.ts
@@ -103,13 +103,13 @@ export function isPublicAddress(address: string): boolean {
     const hexMapped = /^::ffff:([\da-f]{1,4}):([\da-f]{1,4})$/i.exec(address);
     const target =
         mapped !== null
-            ? mapped[1]
+            ? mapped[1]!
             : hexMapped !== null
               ? [
-                    Number.parseInt(hexMapped[1], 16) >> 8,
-                    Number.parseInt(hexMapped[1], 16) & 255,
-                    Number.parseInt(hexMapped[2], 16) >> 8,
-                    Number.parseInt(hexMapped[2], 16) & 255,
+                    Number.parseInt(hexMapped[1]!, 16) >> 8,
+                    Number.parseInt(hexMapped[1]!, 16) & 255,
+                    Number.parseInt(hexMapped[2]!, 16) >> 8,
+                    Number.parseInt(hexMapped[2]!, 16) & 255,
                 ].join('.')
               : address;
 
@@ -125,6 +125,7 @@ export function isPublicAddress(address: string): boolean {
     const parts = target.split('.').map(Number);
     if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
     const [a, b] = parts;
+    if (a === undefined || b === undefined) return false;
     if (a === 0 || a === 10 || a === 127) return false;
     if (a === 169 && b === 254) return false; // リンクローカル (雲のメタデータもここ)
     if (a === 172 && b >= 16 && b <= 31) return false;
@@ -168,7 +169,7 @@ async function resolvable(host: string): Promise<string> {
     for (const address of found) {
         if (!isPublicAddress(address)) throw new Refused(`内側の住所です (${host} → ${address})`);
     }
-    return found[0];
+    return found[0]!;
 }
 
 /**
@@ -350,7 +351,7 @@ export async function confirmReachable(
     // `example.jp` でも `https://example.jp/x` でも受ける
     const host = destination.includes('://')
         ? new URL(destination).hostname
-        : destination.replace(/^\/+/, '').split('/')[0];
+        : (destination.replace(/^\/+/, '').split('/')[0] ?? '');
     if (host === '') throw new Refused('宛先がありません');
 
     const started = Date.now();

--- a/src/lib/server/cm.test.ts
+++ b/src/lib/server/cm.test.ts
@@ -352,9 +352,9 @@ describe('ffprobe の読み取り', () => {
 describe('join_logo_scp の出力', () => {
     test('avs の Trim をフレームから秒に直す', () => {
         const ranges = parseTrimRanges('Trim(0,2996)++Trim(4497,8993)', 30000 / 1001);
-        expect(ranges[0].start).toBeCloseTo(0, 3);
-        expect(ranges[0].end).toBeCloseTo(99.99, 1);
-        expect(ranges[1].start).toBeCloseTo(150.05, 1);
+        expect(ranges[0]!.start).toBeCloseTo(0, 3);
+        expect(ranges[0]!.end).toBeCloseTo(99.99, 1);
+        expect(ranges[1]!.start).toBeCloseTo(150.05, 1);
     });
 
     test('Trim が無ければ空', () => {

--- a/src/lib/server/cm.ts
+++ b/src/lib/server/cm.ts
@@ -160,7 +160,7 @@ export function detectCmRanges(
     const points = boundaries(silences, duration);
     const segments: Range[] = [];
     for (let i = 0; i < points.length - 1; i++) {
-        segments.push({ start: points[i], end: points[i + 1] });
+        segments.push({ start: points[i]!, end: points[i + 1]! });
     }
 
     // 連続するCM尺セグメントを1つのCMブロックにまとめる
@@ -324,7 +324,7 @@ export function fields(out: string): Map<string, string> {
 
 /** `30000/1001` の形のフレームレートを数に直す。読めなければ NaN */
 export function parseFrameRate(value: string | undefined): number {
-    const [num, den] = (value ?? '').trim().split('/').map(Number);
+    const [num = NaN, den] = (value ?? '').trim().split('/').map(Number);
     const fps = den ? num / den : num;
     return Number.isFinite(fps) && fps > 0 ? fps : NaN;
 }

--- a/src/lib/server/conflict.test.ts
+++ b/src/lib/server/conflict.test.ts
@@ -42,8 +42,8 @@ describe('assign', () => {
         );
         expect(accepted.map((a) => a.reservation.id).sort()).toEqual([1, 2]);
         expect(rejected).toHaveLength(1);
-        expect(rejected[0].reservation.id).toBe(3);
-        expect(rejected[0].reason).toContain('GR のチューナー 2 本');
+        expect(rejected[0]!.reservation.id).toBe(3);
+        expect(rejected[0]!.reason).toContain('GR のチューナー 2 本');
     });
 
     test('優先度が高いものを残す', () => {
@@ -56,7 +56,7 @@ describe('assign', () => {
             GR2,
         );
         expect(accepted.map((a) => a.reservation.id)).toContain(3);
-        expect(rejected[0].reservation.priority).toBe(1);
+        expect(rejected[0]!.reservation.priority).toBe(1);
     });
 
     test('時間が重ならなければ本数を消費しない', () => {

--- a/src/lib/server/conflict.ts
+++ b/src/lib/server/conflict.ts
@@ -157,8 +157,8 @@ export function assign<T extends Assignable>(
         /** マージンをどかしてもらった区間。あとで相手を縮める */
         const pushed: number[] = [];
         for (let i = 0; i + 1 < points.length; i++) {
-            const from = points[i];
-            const to = points[i + 1];
+            const from = points[i]!;
+            const to = points[i + 1]!;
             const here = holding(rivals, from);
             const all = new Set([candidate.channel, ...here.all]);
             const body = new Set([candidate.channel, ...here.body]);
@@ -247,7 +247,7 @@ export function rivalsOf(occupants: Iterable<Occupant>, margins: Margins): Rival
             let high = list.length;
             while (low < high) {
                 const mid = (low + high) >> 1;
-                if (list[mid].start_at < at - slack) low = mid + 1;
+                if (list[mid]!.start_at < at - slack) low = mid + 1;
                 else high = mid;
             }
             return low;
@@ -290,7 +290,7 @@ export function contending(
     // 総当たりにしない。ゆるい条件のルールは数千件に当たるので、
     // 1件ずつ全件と突き合わせると番組表の二乗ぶん回ることになる
     for (let at = rivals.from(mine.from); at < rivals.list.length; at++) {
-        const other = rivals.list[at];
+        const other = rivals.list[at]!;
         const theirs = window(other, margins);
         // 並びは開始順。これより後ろは全部この番組より後に始まる
         if (theirs.from >= mine.to) break;

--- a/src/lib/server/encoder.ts
+++ b/src/lib/server/encoder.ts
@@ -88,7 +88,7 @@ export function pickSmooth(ratios: number[], threshold = config.fpsSurvive): boo
     const valid = ratios.filter((r) => Number.isFinite(r) && r > 0);
     if (valid.length === 0) return true;
     const sorted = [...valid].sort((a, b) => a - b);
-    const median = sorted[Math.floor(sorted.length / 2)];
+    const median = sorted[Math.floor(sorted.length / 2)] ?? 0;
     return median > threshold;
 }
 
@@ -681,8 +681,8 @@ export function inputProgress(inputBytes: number) {
         }
 
         const mb = (bytes: number) => (bytes / 1024 / 1024).toFixed(0);
-        const sizeMb = (parseInt(block['total_size'], 10) / 1024 / 1024).toFixed(1);
-        const rateMbps = (parseFloat(block['bitrate']) / 1000).toFixed(2);
+        const sizeMb = (parseInt(block['total_size'] ?? '', 10) / 1024 / 1024).toFixed(1);
+        const rateMbps = (parseFloat(block['bitrate'] ?? '') / 1000).toFixed(2);
         return {
             percent,
             etaMs,
@@ -1409,7 +1409,7 @@ async function runJob(jobId: number): Promise<void> {
                         .where(eq(encodeJobs.id, jobId))
                         .run();
                 }
-                const before = attempts[i - 1].hardware;
+                const before = attempts[i - 1]!.hardware;
                 if (attempt.hardware !== before) {
                     setStep(
                         jobId,
@@ -1458,6 +1458,8 @@ async function runJob(jobId: number): Promise<void> {
 
     // 主は AV1 (小さいので既定の再生に向く)。無ければ焼いたほう
     const primary = placed.find((p) => p.codec === 'av1') ?? placed[0];
+    // 上のループは焼けなければ return しているので、ここに来れば1本はある
+    if (primary === undefined) throw new Error('焼いたものが1本も無いのに置きに来ました');
     const alt = placed.find((p) => p.path !== primary.path)?.path ?? null;
     const output = primary.path;
 

--- a/src/lib/server/files.ts
+++ b/src/lib/server/files.ts
@@ -220,7 +220,7 @@ function sweepLeftovers(): { swept: number; strays: number; pruned: number } {
 function orphan(path: string, videos: Set<string>): boolean {
     // 索引や作業ファイル。動画の名前をまるごと頭に持つ (`….m2ts.dtvi`)
     const trailing = /^(.+\.(?:m2ts|ts|mkv|mp4))\.[^/]+$/i.exec(path);
-    if (trailing !== null) return !videos.has(trailing[1]);
+    if (trailing?.[1] !== undefined) return !videos.has(trailing[1]);
     // NFO・ポスター・データ放送。動画の拡張子を取り替えた形 (metadata.ts の
     // SIDECAR_SUFFIXES。もう作らないものも前に置いたのが残っているので拾う。tvshow.nfo も同じ道で片付く)
     const base = SIDECAR_ORPHAN.exec(path);

--- a/src/lib/server/live.test.ts
+++ b/src/lib/server/live.test.ts
@@ -3,7 +3,7 @@ import { type AudioSide, audioTracks } from '$lib/arib';
 import { codecsFor, encodeArgs, whyNotTuned } from './live';
 
 /** 1本目の音声をそのまま。番組表が何も言っていないときの既定 */
-const stereo = audioTracks([])[0];
+const stereo = audioTracks([])[0]!;
 /** デュアルモノの中から選ぶ。0=主音声 1=副音声 2=主+副 */
 const dual = (side: AudioSide) => {
     const tracks = audioTracks([{ componentType: 2, langs: ['jpn', 'eng'] }]);
@@ -135,7 +135,7 @@ describe('ライブの焼き方', () => {
             { componentType: 3, langs: ['jpn'] },
             { componentType: 3, langs: ['eng'] },
         ]);
-        const args = encodeArgs(1032, tracks[1]);
+        const args = encodeArgs(1032, tracks[1]!);
         expect(args).toContain('0:p:1032:a:1');
         expect(args).not.toContain('0:p:1032:a:0');
     });
@@ -290,7 +290,7 @@ describe('音声も組で決まる', () => {
 
     /** デュアルモノの配り直しは音声の形より手前。どちらを選んでも効く */
     test('左右の配り直しは形によらず効く', () => {
-        const sub = audioTracks([{ componentType: 2, langs: ['jpn', 'eng'] }])[1];
+        const sub = audioTracks([{ componentType: 2, langs: ['jpn', 'eng'] }])[1]!;
         for (const codec of ['h264', 'av1'] as const) {
             const out = encodeArgs(1024, sub, codec);
             expect(out[out.indexOf('-af') + 1]).toContain('c0=c1');

--- a/src/lib/server/logo-data.ts
+++ b/src/lib/server/logo-data.ts
@@ -105,7 +105,8 @@ function latest(dir: string): string | null {
         const files = readdirSync(dir)
             .filter((name) => name.endsWith('.lgd'))
             .sort();
-        return files.length === 0 ? null : join(dir, files[files.length - 1]);
+        const newest = files.at(-1);
+        return newest === undefined ? null : join(dir, newest);
     } catch {
         // まだ1本も録っていない局。置き場ごと無い
         return null;
@@ -137,14 +138,15 @@ export function readLearnedLogo(serviceId: number): LearnedLogo | null {
     const depths = new Int16Array(width * height);
     let depth = 0;
     for (let i = 0; i < width * height; i++) {
-        depths[i] = view.getInt16(HEADER + i * PIXEL, true);
-        depth = Math.max(depth, depths[i]);
+        const value = view.getInt16(HEADER + i * PIXEL, true);
+        depths[i] = value;
+        depth = Math.max(depth, value);
     }
     // いちばん濃いところを白にする。満点で割ると、薄いものが真っ黒で形が見えない
     const top = Math.max(1, Math.min(FULL_DEPTH, depth));
     const gray = new Uint8Array(width * height);
-    for (let i = 0; i < depths.length; i++) {
-        gray[i] = Math.round((Math.max(0, Math.min(top, depths[i])) / top) * 255);
+    for (const [i, value] of depths.entries()) {
+        gray[i] = Math.round((Math.max(0, Math.min(top, value)) / top) * 255);
     }
 
     let learnedAt = 0;

--- a/src/lib/server/oidc.ts
+++ b/src/lib/server/oidc.ts
@@ -230,8 +230,15 @@ const SKEW = 60;
  */
 export async function verify(token: string, nonce: string, at = Date.now()): Promise<Claims> {
     const parts = token.split('.');
-    if (parts.length !== 3) throw new Error('ID トークンの形が違います');
     const [rawHeader, rawPayload, rawSignature] = parts;
+    if (
+        parts.length !== 3 ||
+        rawHeader === undefined ||
+        rawPayload === undefined ||
+        rawSignature === undefined
+    ) {
+        throw new Error('ID トークンの形が違います');
+    }
 
     const header = JSON.parse(new TextDecoder().decode(decodeBase64Url(rawHeader))) as {
         alg?: string;

--- a/src/lib/server/recorded-bml.test.ts
+++ b/src/lib/server/recorded-bml.test.ts
@@ -84,11 +84,11 @@ describe('saveRecordedBml / loadRecordedBml', () => {
         const done = loaded.find((item) => item.message.type === 'moduleDownloaded');
         if (done?.message.type !== 'moduleDownloaded') throw new Error('moduleDownloaded が無い');
         expect(done.at).toBe(10_000);
-        expect(Buffer.from(done.message.files[0].dataBase64, 'base64').toString()).toContain(
+        expect(Buffer.from(done.message.files[0]!.dataBase64, 'base64').toString()).toContain(
             '録画のデータ放送',
         );
         // **番組の名乗りが頭に入っている。** 描く側はこれが来るまで入口を開かない
-        const info = loaded[0].message;
+        const info = loaded[0]!.message;
         if (info.type !== 'programInfo') throw new Error('programInfo が頭に無い');
         expect(info.serviceId).toBe(1024);
         expect(info.eventName).toBe('録画のテスト');
@@ -101,7 +101,7 @@ describe('saveRecordedBml / loadRecordedBml', () => {
     test('名乗りを書いていなかった頃のサイドカーには、読むときに足す', () => {
         const old = [{ at: 0, message: { type: 'pmt' as const, components: [] } }];
         const fixed = withProgramInfo(old, recording(T));
-        expect(fixed[0].message.type).toBe('programInfo');
+        expect(fixed[0]!.message.type).toBe('programInfo');
         expect(fixed).toHaveLength(2);
         // 空 (データ放送を持たない録画) には足さない — 「出せない」のままにする
         expect(withProgramInfo([], recording(T))).toEqual([]);

--- a/src/lib/server/relayout.ts
+++ b/src/lib/server/relayout.ts
@@ -61,7 +61,8 @@ function sweepNfo(videoPath: string): boolean {
  */
 function sweepOldStrays(rec: Recording, oldDir: string, moved: ReadonlySet<string>): void {
     if (!existsSync(oldDir)) return;
-    const base = basename(libraryFamily(rec)[0], '.mkv');
+    // 先頭は素の `.mkv` (`libraryFamily` の並び)
+    const base = basename(libraryFamily(rec)[0]!, '.mkv');
     const variants = [
         `${base}.mkv`,
         `${base} [${rec.id}].mkv`,

--- a/src/lib/server/scan.test.ts
+++ b/src/lib/server/scan.test.ts
@@ -160,8 +160,8 @@ describe('1チャンネルの読み取り', () => {
         );
         expect(error).toBeNull();
         expect(services?.map((s) => s.serviceId)).toEqual([1024, 1025]);
-        expect(services?.[0].name).toBe('TOKYO MX1');
-        expect(services?.[0].remoteControlKeyId).toBe(6);
+        expect(services?.[0]?.name).toBe('TOKYO MX1');
+        expect(services?.[0]?.remoteControlKeyId).toBe(6);
     });
 
     test('何も出てこなければ受信できていない', async () => {

--- a/src/lib/server/scan.ts
+++ b/src/lib/server/scan.ts
@@ -303,9 +303,9 @@ class Scanner {
         const order: Record<string, number> = { GR: 0, BS: 1, CS: 2 };
         return [...this.found.entries()]
             .sort(([a], [b]) => {
-                const [typeA, channelA] = a.split(':');
-                const [typeB, channelB] = b.split(':');
-                return order[typeA] - order[typeB] || channelA.localeCompare(channelB);
+                const [typeA = '', channelA = ''] = a.split(':');
+                const [typeB = '', channelB = ''] = b.split(':');
+                return (order[typeA] ?? 9) - (order[typeB] ?? 9) || channelA.localeCompare(channelB);
             })
             .map(([, entry]) => entry);
     }

--- a/src/lib/server/scramble.ts
+++ b/src/lib/server/scramble.ts
@@ -56,7 +56,7 @@ export function scrambledRatio(path: string): number {
                 // 同期が取れていないファイルは判定しない。誤って解除に回すより素通しがまし
                 if (buffer[i] !== SYNC) return 0;
                 total++;
-                if ((buffer[i + 3] & 0xc0) !== 0) scrambled++;
+                if ((buffer[i + 3]! & 0xc0) !== 0) scrambled++;
             }
         }
         return total === 0 ? 0 : scrambled / total;

--- a/src/lib/server/settings.ts
+++ b/src/lib/server/settings.ts
@@ -171,7 +171,7 @@ export function settings(): Settings {
     const picked = parseCodecs(codec);
     const codecs = flag('encode', true) ? picked : [];
     // 主は先頭 (parseCodecs が AV1 を先頭に寄せている — 小さいので既定の再生に向く)
-    const primary: VideoCodec = codecs.length === 0 ? 'none' : codecs[0];
+    const primary: VideoCodec = codecs[0] ?? 'none';
     return {
         codec: primary,
         codecs,

--- a/src/lib/server/subtitle.ts
+++ b/src/lib/server/subtitle.ts
@@ -180,7 +180,7 @@ export async function buildPgs(
         const out = new Uint8Array(size);
         let at = 0;
         while (at < size) {
-            const part = queue[0];
+            const part = queue[0]!;
             const need = size - at;
             if (part.length <= need) {
                 out.set(part, at);

--- a/src/lib/server/title.ts
+++ b/src/lib/server/title.ts
@@ -55,7 +55,7 @@ export function parseTitle(rawName: string): ParsedTitle {
 
     const bracket = series.match(BRACKET_SUBTITLE);
     if (bracket !== null) {
-        subtitle = bracket[1].trim();
+        subtitle = (bracket[1] ?? '').trim();
         series = series.slice(0, bracket.index).trim();
     }
 

--- a/src/lib/ts/ait.test.ts
+++ b/src/lib/ts/ait.test.ts
@@ -59,9 +59,9 @@ describe('AIT の中身', () => {
         const ait = parseAit(
             aitSection([{ organisationId: 1, applicationId: 2, base: 'https://example.jp/app' }]),
         );
-        expect(ait?.applications[0].url).toBe('https://example.jp/app');
+        expect(ait?.applications[0]?.url).toBe('https://example.jp/app');
         // 名前は放送が入れていないことがある。空でも捨てない
-        expect(ait?.applications[0].name).toBe('');
+        expect(ait?.applications[0]?.name).toBe('');
     });
 
     test('起動のしかたはそのまま持つ', () => {
@@ -70,7 +70,7 @@ describe('AIT の中身', () => {
                 { organisationId: 1, applicationId: 2, controlCode: CONTROL.present, base: 'https://a/' },
             ]),
         );
-        expect(ait?.applications[0].controlCode).toBe(CONTROL.present);
+        expect(ait?.applications[0]?.controlCode).toBe(CONTROL.present);
     });
 
     /*
@@ -108,8 +108,8 @@ describe('TS から見つける', () => {
         const reader = new AitReader(1024);
         const found = reader.feed(stream({ base: 'https://example.jp/', path: 'x.html', name: 'テスト' }));
         expect(found).toHaveLength(1);
-        expect(found[0].applications[0].url).toBe('https://example.jp/x.html');
-        expect(found[0].applications[0].name).toBe('テスト');
+        expect(found[0]!.applications[0]!.url).toBe('https://example.jp/x.html');
+        expect(found[0]!.applications[0]!.name).toBe('テスト');
     });
 
     test('AIT が先に来ても、PMT を読むまでは拾わない', () => {

--- a/src/lib/ts/ait.ts
+++ b/src/lib/ts/ait.ts
@@ -110,7 +110,7 @@ function transportUrl(body: Uint8Array): string | null {
     if (body.length < 3) return null;
     if (u16(body, 0) !== PROTOCOL_HTTP) return null;
     // [0..1] protocol_id, [2] transport_protocol_label, [3] URL_base_length
-    const baseLength = body[3];
+    const baseLength = body[3]!;
     if (body.length < 4 + baseLength) return null;
     return new TextDecoder().decode(body.subarray(4, 4 + baseLength));
 }
@@ -124,7 +124,7 @@ function transportUrl(body: Uint8Array): string | null {
 function applicationName(body: Uint8Array): string {
     // [0..2] ISO_639_language_code, [3] application_name_length
     if (body.length < 4) return '';
-    const length = body[3];
+    const length = body[3]!;
     if (body.length < 4 + length) return '';
     return decodeAribText(body.subarray(4, 4 + length)).trim();
 }
@@ -136,11 +136,11 @@ function applicationName(body: Uint8Array): string {
 export function parseAit(section: Uint8Array): Ait | null {
     if (section[0] !== TABLE_AIT || section.length < 16) return null;
     const applicationType = u16(section, 3) & 0x7fff;
-    const commonLength = ((section[8] & 0x0f) << 8) | section[9];
+    const commonLength = ((section[8]! & 0x0f) << 8) | section[9]!;
     let at = 10 + commonLength;
     const end = section.length - 4;
     if (at + 2 > end) return null;
-    const loopLength = ((section[at] & 0x0f) << 8) | section[at + 1];
+    const loopLength = ((section[at]! & 0x0f) << 8) | section[at + 1]!;
     at += 2;
     const stop = Math.min(at + loopLength, end);
 
@@ -148,8 +148,8 @@ export function parseAit(section: Uint8Array): Ait | null {
     while (at + 9 <= stop) {
         const organisationId = u32(section, at);
         const applicationId = u16(section, at + 4);
-        const controlCode = section[at + 6];
-        const infoLength = ((section[at + 7] & 0x0f) << 8) | section[at + 8];
+        const controlCode = section[at + 6]!;
+        const infoLength = ((section[at + 7]! & 0x0f) << 8) | section[at + 8]!;
         const info = section.subarray(at + 9, at + 9 + infoLength);
         at += 9 + infoLength;
 
@@ -231,7 +231,7 @@ function pmtPidOf(section: Uint8Array, serviceId: number): number | null {
     const end = section.length - 4;
     for (let at = 8; at + 4 <= end; at += 4) {
         if (u16(section, at) !== serviceId) continue;
-        return ((section[at + 2] & 0x1f) << 8) | section[at + 3];
+        return ((section[at + 2]! & 0x1f) << 8) | section[at + 3]!;
     }
     return null;
 }

--- a/src/lib/ts/aribtext.ts
+++ b/src/lib/ts/aribtext.ts
@@ -147,7 +147,7 @@ export function decodeAribText(data: Uint8Array): string {
     };
 
     while (at < data.length) {
-        const byte = data[at];
+        const byte = data[at]!;
 
         // --- 制御符号 (C0) ------------------------------------------------
         if (byte <= 0x20 || byte === 0x7f || byte === 0xa0 || byte === 0xff) {
@@ -194,7 +194,7 @@ export function decodeAribText(data: Uint8Array): string {
             at++;
             if (byte === 0x9b) {
                 // CSI。引数のあと 0x40 以上の終端バイトが来るまで読み飛ばす
-                while (at < data.length && data[at] < 0x40) at++;
+                while (at < data.length && data[at]! < 0x40) at++;
                 at++;
                 continue;
             }
@@ -214,7 +214,7 @@ export function decodeAribText(data: Uint8Array): string {
         // --- 図形文字 ---------------------------------------------------
         const area = single !== null ? single : byte >= 0xa1 ? gr : gl;
         single = null;
-        const set = g[area];
+        const set = g[area]!;
         const first = byte & 0x7f;
 
         if (set.bytes === 2) {
@@ -291,7 +291,7 @@ function afterEscape(
                 designate(next - 0x28, { bytes: 2, kind: 'blank' });
                 return at + 4;
             }
-            designate(next - 0x28, CHARSETS.get(data[at + 2]));
+            designate(next - 0x28, CHARSETS.get(data[at + 2]!));
             return at + 3;
         }
         designate(0, CHARSETS.get(next));
@@ -306,7 +306,7 @@ function afterEscape(
             designate(target, { bytes: 1, kind: 'blank' });
             return at + 3;
         }
-        designate(target, CHARSETS.get(data[at + 1]));
+        designate(target, CHARSETS.get(data[at + 1]!));
         return at + 2;
     }
 

--- a/src/lib/ts/bml.test.ts
+++ b/src/lib/ts/bml.test.ts
@@ -99,16 +99,16 @@ describe('moduleFiles', () => {
             'multipart/mixed',
         );
         expect(files.map((file) => file.contentLocation)).toEqual(['/startup.bml', '/logo.png']);
-        expect(Buffer.from(files[0].dataBase64, 'base64').toString()).toBe('<bml/>');
-        expect(files[1].contentType.type).toBe('image');
+        expect(Buffer.from(files[0]!.dataBase64, 'base64').toString()).toBe('<bml/>');
+        expect(files[1]!.contentType.type).toBe('image');
     });
 
     /** 中身が1つのモジュールは包まれていない。置き場所は BML 側が知っている */
     test('multipart でなければ丸ごと1ファイル', () => {
         const files = moduleFiles(new TextEncoder().encode('PNG'), 'image/png');
         expect(files).toHaveLength(1);
-        expect(files[0].contentLocation).toBeNull();
-        expect(files[0].contentType.subtype).toBe('png');
+        expect(files[0]!.contentLocation).toBeNull();
+        expect(files[0]!.contentType.subtype).toBe('png');
     });
 });
 
@@ -169,7 +169,7 @@ describe('BmlDecoder', () => {
         if (done?.type !== 'moduleDownloaded') throw new Error('moduleDownloaded が出ていない');
         expect(done.componentId).toBe(COMPONENT_TAG);
         expect(done.files.map((file) => file.contentLocation)).toEqual(['/startup.bml', '/40/logo.png']);
-        expect(Buffer.from(done.files[0].dataBase64, 'base64').toString()).toContain('データ放送');
+        expect(Buffer.from(done.files[0]!.dataBase64, 'base64').toString()).toContain('データ放送');
     });
 
     /** 大きいモジュールは何ブロックにも割れる。順番は保証されない */
@@ -191,7 +191,7 @@ describe('BmlDecoder', () => {
         );
         const done = out.find((message) => message.type === 'moduleDownloaded');
         if (done?.type !== 'moduleDownloaded') throw new Error('moduleDownloaded が出ていない');
-        expect(Buffer.from(done.files[0].dataBase64, 'base64').toString()).toContain('あああ');
+        expect(Buffer.from(done.files[0]!.dataBase64, 'base64').toString()).toContain('あああ');
     });
 
     /*

--- a/src/lib/ts/bml.ts
+++ b/src/lib/ts/bml.ts
@@ -77,24 +77,24 @@ const COMPRESSION_ZLIB = 0;
 export function parseBxmlInfo(data: Uint8Array): AdditionalAribBXMLInfo {
     let at = 0;
     // 00 のみ運用 (データカルーセル伝送方式およびイベントメッセージ伝送方式)
-    const transmissionFormat = (data[at] >> 6) & 0b11;
+    const transmissionFormat = (data[at]! >> 6) & 0b11;
     // component_tag=0x40 のとき必ず1。startup.xml が最初に起動される
-    const entryPointFlag = ((data[at] >> 5) & 1) === 1;
+    const entryPointFlag = ((data[at]! >> 5) & 1) === 1;
     const info: AdditionalAribBXMLInfo = { transmissionFormat, entryPointFlag };
 
     if (entryPointFlag) {
-        const autoStartFlag = ((data[at] >> 4) & 1) === 1;
+        const autoStartFlag = ((data[at]! >> 4) & 1) === 1;
         /*
          * 画面の大きさ。運用されるのは 0011 (960x540)、0100 (640x480 16:9)、
          * 0101 (640x480 4:3) の3つ
          */
-        const documentResolution = data[at] & 0x0f;
+        const documentResolution = data[at]! & 0x0f;
         at++;
-        const useXML = ((data[at] >> 7) & 1) === 1;
-        const defaultVersionFlag = ((data[at] >> 6) & 1) === 1;
+        const useXML = ((data[at]! >> 7) & 1) === 1;
+        const defaultVersionFlag = ((data[at]! >> 6) & 1) === 1;
         // BS/CS では 0 のとき単独視聴不可。地上波は常に1
-        const independentFlag = ((data[at] >> 5) & 1) === 1;
-        const styleForTVFlag = ((data[at] >> 4) & 1) === 1;
+        const independentFlag = ((data[at]! >> 5) & 1) === 1;
+        const styleForTVFlag = ((data[at]! >> 4) & 1) === 1;
         at++;
         // 既定は BS の 1.0。地上波は3、CS は2が入ってくる
         info.entryPointInfo = {
@@ -124,12 +124,12 @@ export function parseBxmlInfo(data: Uint8Array): AdditionalAribBXMLInfo {
 
     if (transmissionFormat === 0) {
         // additional_arib_carousel_info (STD-B24 第三分冊 第三編 C.1)
-        const dataEventId = (data[at] >> 4) & 0x0f;
-        const eventSectionFlag = ((data[at] >> 3) & 1) === 1;
+        const dataEventId = (data[at]! >> 4) & 0x0f;
+        const eventSectionFlag = ((data[at]! >> 3) & 1) === 1;
         at++;
-        const ondemandRetrievalFlag = ((data[at] >> 7) & 1) === 1;
-        const fileStorableFlag = ((data[at] >> 6) & 1) === 1;
-        const startPriority = (data[at] >> 5) & 1;
+        const ondemandRetrievalFlag = ((data[at]! >> 7) & 1) === 1;
+        const fileStorableFlag = ((data[at]! >> 6) & 1) === 1;
+        const startPriority = (data[at]! >> 5) & 1;
         info.additionalAribCarouselInfo = {
             dataEventId,
             eventSectionFlag,
@@ -173,17 +173,17 @@ function parsePmt(section: Uint8Array): ComponentPMT[] {
 /** ストリーム記述子 (table_id 0x3D)。NPT と イベントメッセージが載っている */
 function parseEsEvents(section: Uint8Array): ESEvent[] {
     const events: ESEvent[] = [];
-    const length = ((section[1] & 0x0f) << 8) | section[2];
+    const length = ((section[1]! & 0x0f) << 8) | section[2]!;
     const body = section.subarray(8, Math.min(3 + length - 4, section.length));
     for (const [tag, descriptor] of descriptors(body)) {
         if (tag === 0x17 && descriptor.length >= 18) {
             // NPT 参照記述子。放送の時計と番組内の時刻を結び付ける
             events.push({
                 type: 'nptReference',
-                postDiscontinuityIndicator: (descriptor[0] & 0x80) !== 0,
-                dsmContentId: descriptor[0] & 0x7f,
-                STCReference: u32(descriptor, 2) + (descriptor[1] & 1) * 0x100000000,
-                NPTReference: u32(descriptor, 10) + (descriptor[9] & 1) * 0x100000000,
+                postDiscontinuityIndicator: (descriptor[0]! & 0x80) !== 0,
+                dsmContentId: descriptor[0]! & 0x7f,
+                STCReference: u32(descriptor, 2) + (descriptor[1]! & 1) * 0x100000000,
+                NPTReference: u32(descriptor, 10) + (descriptor[9]! & 1) * 0x100000000,
                 scaleNumerator: u16(descriptor, 14),
                 scaleDenominator: u16(descriptor, 16),
             });
@@ -191,7 +191,7 @@ function parseEsEvents(section: Uint8Array): ESEvent[] {
             // 汎用イベントメッセージ記述子。運用されるのは time_mode 0 と 2 だけ
             const groupId = (u16(descriptor, 0) >> 4) & 0x0fff;
             const timeMode = descriptor[2];
-            const eventMessageType = descriptor[8];
+            const eventMessageType = descriptor[8]!;
             const eventMessageId = u16(descriptor, 9);
             const privateDataByte = [...descriptor.subarray(11)];
             if (timeMode === 0) {
@@ -208,7 +208,7 @@ function parseEsEvents(section: Uint8Array): ESEvent[] {
                     type: 'nptEvent',
                     timeMode: 2,
                     eventMessageGroupId: groupId,
-                    eventMessageNPT: u32(descriptor, 4) + (descriptor[3] & 1) * 0x100000000,
+                    eventMessageNPT: u32(descriptor, 4) + (descriptor[3]! & 1) * 0x100000000,
                     eventMessageType,
                     eventMessageId,
                     privateDataByte,

--- a/src/lib/ts/bytes.ts
+++ b/src/lib/ts/bytes.ts
@@ -13,7 +13,7 @@
  * ([eit.ts](eit.ts)) では、繋ぐ必要のないほうが多数です
  */
 export function joinBytes(parts: Uint8Array[]): Uint8Array {
-    if (parts.length === 1) return parts[0];
+    if (parts.length === 1) return parts[0]!;
     let total = 0;
     for (const part of parts) total += part.length;
     const out = new Uint8Array(total);

--- a/src/lib/ts/captions.test.ts
+++ b/src/lib/ts/captions.test.ts
@@ -70,7 +70,7 @@ describe('trimCues', () => {
         // まだどれも過ぎていないので、落ちるのは上限のぶんだけ
         const kept = trimCues(cues, 0);
         expect(kept).toHaveLength(KEEP_CUES);
-        expect(kept[kept.length - 1].at).toBe(1000 + KEEP_CUES + 49);
+        expect(kept[kept.length - 1]!.at).toBe(1000 + KEEP_CUES + 49);
     });
 });
 

--- a/src/lib/ts/captions.ts
+++ b/src/lib/ts/captions.ts
@@ -60,7 +60,7 @@ export function trimCues(cues: Cue[], at: number): Cue[] {
     // 過ぎたものの中でいちばん新しい1つより前は、もう使わない
     let keepFrom = 0;
     for (let i = 0; i < cues.length; i++) {
-        if (cues[i].at > at) break;
+        if (cues[i]!.at > at) break;
         keepFrom = i;
     }
     const kept = cues.slice(keepFrom);
@@ -73,7 +73,7 @@ export function trimCues(cues: Cue[], at: number): Cue[] {
  * 同じ時刻のものが来たら**後から来たほうを採る** (出し直しなので新しいほうが正しい)。
  */
 export function insertCue(cues: Cue[], cue: Cue): Cue[] {
-    if (cues.length === 0 || cues[cues.length - 1].at < cue.at) return [...cues, cue];
+    if (cues.length === 0 || cues[cues.length - 1]!.at < cue.at) return [...cues, cue];
     const out = cues.filter((held) => held.at !== cue.at);
     const at = out.findIndex((held) => held.at > cue.at);
     if (at < 0) return [...out, cue];

--- a/src/lib/ts/clock.ts
+++ b/src/lib/ts/clock.ts
@@ -63,14 +63,18 @@ export interface Anchor {
 export function readPcr(packet: Uint8Array): number {
     if (packet.length < 12 || packet[0] !== 0x47) return Number.NaN;
     // 適応フィールドを持つか (2 = 適応のみ, 3 = 適応 + 中身)
-    const control = (packet[3] >> 4) & 0x03;
+    const control = (packet[3]! >> 4) & 0x03;
     if (control !== 2 && control !== 3) return Number.NaN;
-    const length = packet[4];
+    const length = packet[4]!;
     if (length < 7) return Number.NaN;
     // PCR_flag
-    if ((packet[5] & 0x10) === 0) return Number.NaN;
+    if ((packet[5]! & 0x10) === 0) return Number.NaN;
     const base =
-        packet[6] * 2 ** 25 + packet[7] * 2 ** 17 + packet[8] * 2 ** 9 + packet[9] * 2 + (packet[10] >> 7);
+        packet[6]! * 2 ** 25 +
+        packet[7]! * 2 ** 17 +
+        packet[8]! * 2 ** 9 +
+        packet[9]! * 2 +
+        (packet[10]! >> 7);
     return base / CLOCK;
 }
 
@@ -105,7 +109,7 @@ export class BroadcastClock {
 
     feed(chunk: Uint8Array): void {
         for (const packet of this.packets.feed(chunk)) {
-            const pid = ((packet[1] & 0x1f) << 8) | packet[2];
+            const pid = ((packet[1]! & 0x1f) << 8) | packet[2]!;
             if (this.pcrPid === null || pid === this.pcrPid) {
                 const at = readPcr(packet);
                 if (Number.isFinite(at)) {
@@ -133,7 +137,7 @@ export class BroadcastClock {
 
     private onPmt(section: Uint8Array): void {
         if (section[0] !== TABLE_PMT || section.length < 12) return;
-        const pid = ((section[8] & 0x1f) << 8) | section[9];
+        const pid = ((section[8]! & 0x1f) << 8) | section[9]!;
         // 0x1fff は「PCR を運ぶ ES は無い」の意味
         this.pcrPid = pid === 0x1fff ? null : pid;
     }

--- a/src/lib/ts/data-timeline.test.ts
+++ b/src/lib/ts/data-timeline.test.ts
@@ -43,7 +43,7 @@ const head = bmlHead();
 
 function bmlBody(message: ResponseMessage): string | null {
     if (message.type !== 'moduleDownloaded') return null;
-    return Buffer.from(message.files[0].dataBase64, 'base64').toString();
+    return Buffer.from(message.files[0]!.dataBase64, 'base64').toString();
 }
 
 const T1 = Date.UTC(2026, 7, 9, 12, 0, 0);
@@ -56,8 +56,8 @@ describe('captureDataBroadcast', () => {
         ]);
         const done = timeline.filter((item) => item.message.type === 'moduleDownloaded');
         expect(done).toHaveLength(1);
-        expect(done[0].at).toBe(T1);
-        expect(bmlBody(done[0].message)).toContain('<bml>1</bml>');
+        expect(done[0]!.at).toBe(T1);
+        expect(bmlBody(done[0]!.message)).toContain('<bml>1</bml>');
     });
 
     test('時計を見る前に配られたものは at = null', () => {
@@ -175,12 +175,12 @@ describe('feedFor', () => {
     ];
 
     test('頭から進む = そこまでの変化を順に流す', () => {
-        expect(feedFor(tl, -1, 5_000)).toEqual({ reset: false, messages: [tl[0].message] });
-        expect(feedFor(tl, -1, 20_000)).toEqual({ reset: false, messages: [tl[0].message, tl[1].message] });
+        expect(feedFor(tl, -1, 5_000)).toEqual({ reset: false, messages: [tl[0]!.message] });
+        expect(feedFor(tl, -1, 20_000)).toEqual({ reset: false, messages: [tl[0]!.message, tl[1]!.message] });
     });
 
     test('進んだぶんだけ足す (器はそのまま)', () => {
-        expect(feedFor(tl, 20_000, 70_000)).toEqual({ reset: false, messages: [tl[2].message] });
+        expect(feedFor(tl, 20_000, 70_000)).toEqual({ reset: false, messages: [tl[2]!.message] });
     });
 
     test('戻ったら作り直して積み直す', () => {

--- a/src/lib/ts/dsmcc.ts
+++ b/src/lib/ts/dsmcc.ts
@@ -34,11 +34,11 @@ const MODULE_DESC_COMPRESSION = 0xc2;
 const DEFAULT_BLOCK_SIZE = 4066;
 
 export function u16(data: Uint8Array, at: number): number {
-    return (data[at] << 8) | data[at + 1];
+    return (data[at]! << 8) | data[at + 1]!;
 }
 
 export function u32(data: Uint8Array, at: number): number {
-    return ((data[at] << 24) | (data[at + 1] << 16) | (data[at + 2] << 8) | data[at + 3]) >>> 0;
+    return ((data[at]! << 24) | (data[at + 1]! << 16) | (data[at + 2]! << 8) | data[at + 3]!) >>> 0;
 }
 
 /**
@@ -86,7 +86,7 @@ export interface Ddb {
 
 /** DSM-CC セクションの中身 (メッセージ本体) を切り出す */
 function messageOf(section: Uint8Array): Uint8Array | null {
-    const length = ((section[1] & 0x0f) << 8) | section[2];
+    const length = ((section[1]! & 0x0f) << 8) | section[2]!;
     const end = 3 + length - 4;
     if (end <= 8 || end > section.length) return null;
     return section.subarray(8, end);
@@ -104,7 +104,7 @@ export function parseDii(section: Uint8Array): Dii | null {
     if (message === null || message.length < 20) return null;
 
     const transactionId = u32(message, 4);
-    const adaptationLength = message[9];
+    const adaptationLength = message[9]!;
     let at = 12 + adaptationLength;
     if (at + 20 > message.length) return null;
 
@@ -123,8 +123,8 @@ export function parseDii(section: Uint8Array): Dii | null {
         if (at + 8 > message.length) return null;
         const moduleId = u16(message, at);
         const moduleSize = u32(message, at + 2);
-        const moduleVersion = message[at + 6];
-        const infoLength = message[at + 7];
+        const moduleVersion = message[at + 6]!;
+        const infoLength = message[at + 7]!;
         const info = message.subarray(at + 8, at + 8 + infoLength);
         at += 8 + infoLength;
 
@@ -136,7 +136,7 @@ export function parseDii(section: Uint8Array): Dii | null {
             else if (tag === MODULE_DESC_TYPE) contentType = new TextDecoder('ascii').decode(descriptor);
             else if (tag === MODULE_DESC_COMPRESSION && descriptor.length >= 5) {
                 // 先頭1バイトは符号付き。運用されるのは 0 (zlib) だけ
-                compression = { type: (descriptor[0] << 24) >> 24, originalSize: u32(descriptor, 1) };
+                compression = { type: (descriptor[0]! << 24) >> 24, originalSize: u32(descriptor, 1) };
             }
         }
         modules.push({ moduleId, moduleSize, moduleVersion, name, contentType, compression });
@@ -151,7 +151,7 @@ export function parseDii(section: Uint8Array): Dii | null {
         const length = u16(message, at);
         for (const [tag, descriptor] of descriptors(message.subarray(at + 2, at + 2 + length))) {
             // arib_bxml_privatedata_descriptor (STD-B24 第二分冊 (1/2) 第二編 9.3.4)
-            if (tag === 0xf0 && descriptor.length >= 1) returnToEntry = (descriptor[0] & 0x80) !== 0;
+            if (tag === 0xf0 && descriptor.length >= 1) returnToEntry = (descriptor[0]! & 0x80) !== 0;
         }
     }
     return { downloadId, transactionId, blockSize, modules, returnToEntry };
@@ -164,13 +164,13 @@ export function parseDdb(section: Uint8Array): Ddb | null {
     if (message === null || message.length < 12) return null;
 
     const downloadId = u32(message, 4);
-    const adaptationLength = message[9];
+    const adaptationLength = message[9]!;
     const messageLength = u16(message, 10);
     let at = 12 + adaptationLength;
     if (at + 6 > message.length) return null;
 
     const moduleId = u16(message, at);
-    const moduleVersion = message[at + 2];
+    const moduleVersion = message[at + 2]!;
     const blockNumber = u16(message, at + 4);
     at += 6;
     const size = messageLength - adaptationLength - 6;

--- a/src/lib/ts/eit.test.ts
+++ b/src/lib/ts/eit.test.ts
@@ -41,7 +41,7 @@ function section(events: SynthEvent[], options: Record<string, number> = {}) {
 describe('時刻', () => {
     test('MJD + BCD は日本時間として読む', () => {
         const data = section([event()]);
-        expect(parseEit(data)?.events[0].startAt).toBe(NOON);
+        expect(parseEit(data)?.events[0]?.startAt).toBe(NOON);
     });
 
     test('全ビット1は「未定」。番組表に置けないので null', () => {
@@ -60,16 +60,16 @@ describe('EIT の解析', () => {
     test('番組名と概要を ARIB の文字符号から起こす', () => {
         const parsed = parseEit(section([event()]));
         expect(parsed?.events).toHaveLength(1);
-        expect(parsed?.events[0].name).toBe('テスト番組');
-        expect(parsed?.events[0].description).toBe('これは説明です');
-        expect(parsed?.events[0].duration).toBe(30 * 60 * 1000);
+        expect(parsed?.events[0]?.name).toBe('テスト番組');
+        expect(parsed?.events[0]?.description).toBe('これは説明です');
+        expect(parsed?.events[0]?.duration).toBe(30 * 60 * 1000);
     });
 
     test('局とネットワークは番組にも写す。番組表の JOIN がこれで決まる', () => {
         const parsed = parseEit(section([event()]));
-        expect(parsed?.events[0].serviceId).toBe(SERVICE);
-        expect(parsed?.events[0].originalNetworkId).toBe(NETWORK);
-        expect(parsed?.events[0].transportStreamId).toBe(TSID);
+        expect(parsed?.events[0]?.serviceId).toBe(SERVICE);
+        expect(parsed?.events[0]?.originalNetworkId).toBe(NETWORK);
+        expect(parsed?.events[0]?.transportStreamId).toBe(TSID);
     });
 
     /**
@@ -108,16 +108,16 @@ describe('EIT の解析', () => {
             section([event({ rawDescriptors: [0x4e, one.length, ...one, 0x4e, two.length, ...two] })]),
         );
 
-        expect(parsed?.events[0].extended['番組概要']).toContain('音楽:菅野祐悟');
-        expect(parsed?.events[0].extended['番組概要']).toContain('音楽制作:ONE MUSIC');
-        expect(parsed?.events[0].extended['番組概要']).toContain('音響制作:ビットグルーブプロモーション');
+        expect(parsed?.events[0]?.extended['番組概要']).toContain('音楽:菅野祐悟');
+        expect(parsed?.events[0]?.extended['番組概要']).toContain('音楽制作:ONE MUSIC');
+        expect(parsed?.events[0]?.extended['番組概要']).toContain('音響制作:ビットグルーブプロモーション');
     });
 
     test('詳細情報は見出しごとに繋ぎ直す', () => {
         const parsed = parseEit(
             section([event({ extended: { 出演者: 'ゲスト太郎', 番組内容: 'あらすじ' } })]),
         );
-        expect(parsed?.events[0].extended).toEqual({ 出演者: 'ゲスト太郎', 番組内容: 'あらすじ' });
+        expect(parsed?.events[0]?.extended).toEqual({ 出演者: 'ゲスト太郎', 番組内容: 'あらすじ' });
     });
 
     test('ジャンル・音声・映像', () => {
@@ -164,8 +164,8 @@ describe('EIT の解析', () => {
     });
 
     test('有料放送は free_CA_mode で分かる', () => {
-        expect(parseEit(section([event()]))?.events[0].isFree).toBe(true);
-        expect(parseEit(section([event({ isFree: false })]))?.events[0].isFree).toBe(false);
+        expect(parseEit(section([event()]))?.events[0]?.isFree).toBe(true);
+        expect(parseEit(section([event({ isFree: false })]))?.events[0]?.isFree).toBe(false);
     });
 
     test('他局の番組表 (0x4F / 0x60〜) は読まない', () => {
@@ -379,7 +379,7 @@ describe('EpgReader', () => {
         reader.feed(packets(section([event()])));
         reader.feed(packets(section([event({ name: '差し替え後' })])));
         expect(reader.all()).toHaveLength(1);
-        expect(reader.all()[0].name).toBe('差し替え後');
+        expect(reader.all()[0]!.name).toBe('差し替え後');
     });
 
     /*
@@ -404,7 +404,7 @@ describe('EpgReader', () => {
             ),
         );
 
-        const [program] = reader.all();
+        const program = reader.all()[0]!;
         expect(program.name).toBe('テスト番組');
         expect(program.description).toBe('これは説明です');
         expect(program.extended).toEqual({ 番組内容: 'あらすじ' });
@@ -421,7 +421,7 @@ describe('EpgReader', () => {
         );
         reader.feed(packets(section([event()])));
 
-        const [program] = reader.all();
+        const program = reader.all()[0]!;
         expect(program.name).toBe('テスト番組');
         expect(program.extended).toEqual({ 番組内容: 'あらすじ' });
     });

--- a/src/lib/ts/eit.ts
+++ b/src/lib/ts/eit.ts
@@ -134,12 +134,12 @@ export function parseMjdTime(data: Uint8Array, at: number): number | null {
     }
     if (allOnes) return null;
 
-    const mjd = (data[at] << 8) | data[at + 1];
+    const mjd = (data[at]! << 8) | data[at + 1]!;
     const seconds =
         (mjd - MJD_EPOCH) * 86400 +
-        bcd(data[at + 2]) * 3600 +
-        bcd(data[at + 3]) * 60 +
-        bcd(data[at + 4]) -
+        bcd(data[at + 2]!) * 3600 +
+        bcd(data[at + 3]!) * 60 +
+        bcd(data[at + 4]!) -
         JST_OFFSET;
     return seconds * 1000;
 }
@@ -147,7 +147,7 @@ export function parseMjdTime(data: Uint8Array, at: number): number | null {
 /** BCD 3バイトの尺 (時分秒) を ms に。全ビット1なら「終了未定」 */
 export function parseBcdDuration(data: Uint8Array, at: number): number | null {
     if (data[at] === 0xff && data[at + 1] === 0xff && data[at + 2] === 0xff) return null;
-    return (bcd(data[at]) * 3600 + bcd(data[at + 1]) * 60 + bcd(data[at + 2])) * 1000;
+    return (bcd(data[at]!) * 3600 + bcd(data[at + 1]!) * 60 + bcd(data[at + 2]!)) * 1000;
 }
 
 /**
@@ -175,7 +175,7 @@ const VIDEO_CODEC: Record<number, string> = { 1: 'mpeg2', 5: 'h.264', 9: 'h.265'
 const SAMPLING_RATE: Record<number, number> = { 1: 16000, 2: 22050, 3: 24000, 5: 32000, 6: 44100, 7: 48000 };
 
 const lang = (data: Uint8Array, at: number) =>
-    String.fromCharCode(data[at], data[at + 1], data[at + 2]).toLowerCase();
+    String.fromCharCode(data[at]!, data[at + 1]!, data[at + 2]!).toLowerCase();
 
 /**
  * 記述子を読んで番組の中身を埋める。
@@ -204,21 +204,21 @@ function readDescriptors(event: EitEvent, body: Uint8Array): void {
     for (const [tag, data] of descriptors(body)) {
         switch (tag) {
             case DESC_SHORT_EVENT: {
-                const nameLength = data[3];
+                const nameLength = data[3]!;
                 const textAt = 4 + nameLength;
                 event.name = decodeAribText(data.subarray(4, textAt));
-                const textLength = data[textAt];
+                const textLength = data[textAt]!;
                 event.description = decodeAribText(data.subarray(textAt + 1, textAt + 1 + textLength));
                 break;
             }
             case DESC_EXTENDED_EVENT: {
                 let at = 5;
-                const itemsEnd = 5 + data[4];
+                const itemsEnd = 5 + data[4]!;
                 while (at < itemsEnd && at < data.length) {
-                    const headingLength = data[at];
+                    const headingLength = data[at]!;
                     const heading = decodeAribText(data.subarray(at + 1, at + 1 + headingLength));
                     at += 1 + headingLength;
-                    const textLength = data[at];
+                    const textLength = data[at]!;
                     const text = data.subarray(at + 1, at + 1 + textLength);
                     at += 1 + textLength;
 
@@ -234,13 +234,13 @@ function readDescriptors(event: EitEvent, body: Uint8Array): void {
             }
             case DESC_CONTENT: {
                 for (let at = 0; at + 2 <= data.length; at += 2) {
-                    event.genres.push({ lv1: data[at] >> 4, lv2: data[at] & 0x0f });
+                    event.genres.push({ lv1: data[at]! >> 4, lv2: data[at]! & 0x0f });
                 }
                 break;
             }
             case DESC_COMPONENT: {
-                const streamContent = data[0] & 0x0f;
-                const componentType = data[1];
+                const streamContent = data[0]! & 0x0f;
+                const componentType = data[1]!;
                 event.video = {
                     type: VIDEO_CODEC[streamContent] ?? null,
                     resolution:
@@ -264,15 +264,17 @@ function readDescriptors(event: EitEvent, body: Uint8Array): void {
              *     [残り]   text_char … **放送が付けた名前**
              */
             case DESC_AUDIO_COMPONENT: {
-                const flags = data[5];
+                const flags = data[5]!;
                 const multiLingual = (flags & 0x80) !== 0;
                 const langs = [lang(data, 6)];
                 if (multiLingual) langs.push(lang(data, 9));
                 const text = decodeAribText(data.subarray(6 + (multiLingual ? 6 : 3))).trim();
+                const samplingRate = SAMPLING_RATE[(flags >> 1) & 0x07];
                 event.audios.push({
-                    componentType: data[1],
+                    componentType: data[1]!,
                     langs,
-                    samplingRate: SAMPLING_RATE[(flags >> 1) & 0x07],
+                    // 表に無い符号 (予約) なら付けない
+                    ...(samplingRate === undefined ? {} : { samplingRate }),
                     ...(text === '' ? {} : { text }),
                     main: (flags & 0x40) !== 0,
                 });
@@ -298,36 +300,36 @@ function readDescriptors(event: EitEvent, body: Uint8Array): void {
  */
 export function parseEit(section: Uint8Array): EitSection | null {
     if (section.length < 18) return null;
-    const tableId = section[0];
+    const tableId = section[0]!;
     if (!isEitActual(tableId)) return null;
 
     const result: EitSection = {
         tableId,
-        serviceId: (section[3] << 8) | section[4],
-        version: (section[5] >> 1) & 0x1f,
-        sectionNumber: section[6],
-        lastSectionNumber: section[7],
-        transportStreamId: (section[8] << 8) | section[9],
-        originalNetworkId: (section[10] << 8) | section[11],
-        segmentLastSectionNumber: section[12],
-        lastTableId: section[13],
+        serviceId: (section[3]! << 8) | section[4]!,
+        version: (section[5]! >> 1) & 0x1f,
+        sectionNumber: section[6]!,
+        lastSectionNumber: section[7]!,
+        transportStreamId: (section[8]! << 8) | section[9]!,
+        originalNetworkId: (section[10]! << 8) | section[11]!,
+        segmentLastSectionNumber: section[12]!,
+        lastTableId: section[13]!,
         events: [],
     };
 
     let at = 14;
     const end = section.length - 4;
     while (at + 12 <= end) {
-        const descriptorsLength = ((section[at + 10] & 0x0f) << 8) | section[at + 11];
+        const descriptorsLength = ((section[at + 10]! & 0x0f) << 8) | section[at + 11]!;
         const body = section.subarray(at + 12, at + 12 + descriptorsLength);
         const event: EitEvent = {
             serviceId: result.serviceId,
             transportStreamId: result.transportStreamId,
             originalNetworkId: result.originalNetworkId,
-            eventId: (section[at] << 8) | section[at + 1],
+            eventId: (section[at]! << 8) | section[at + 1]!,
             startAt: parseMjdTime(section, at + 2),
             duration: parseBcdDuration(section, at + 7),
-            runningStatus: (section[at + 10] >> 5) & 0x07,
-            isFree: (section[at + 10] & 0x10) === 0,
+            runningStatus: (section[at + 10]! >> 5) & 0x07,
+            isFree: (section[at + 10]! & 0x10) === 0,
             name: '',
             description: '',
             extended: {},

--- a/src/lib/ts/fmp4.test.ts
+++ b/src/lib/ts/fmp4.test.ts
@@ -29,8 +29,8 @@ describe('fMP4 を割る', () => {
         const splitter = new Fmp4Splitter();
         const out = splitter.feed(join(box('ftyp'), box('moov'), box('moof'), box('mdat')));
         expect(out.map((s) => s.kind)).toEqual(['init', 'media']);
-        expect(out[0].data).toEqual(join(box('ftyp'), box('moov')));
-        expect(out[1].data).toEqual(join(box('moof'), box('mdat')));
+        expect(out[0]!.data).toEqual(join(box('ftyp'), box('moov')));
+        expect(out[1]!.data).toEqual(join(box('moof'), box('mdat')));
     });
 
     test('moof + mdat の組が1枚ずつ出る', () => {
@@ -38,8 +38,8 @@ describe('fMP4 を割る', () => {
         splitter.feed(join(box('ftyp'), box('moov')));
         const out = splitter.feed(join(box('moof', 1), box('mdat', 1), box('moof', 2), box('mdat', 2)));
         expect(out.map((s) => s.kind)).toEqual(['init', 'media', 'media']);
-        expect(out[1].data).toEqual(join(box('moof', 1), box('mdat', 1)));
-        expect(out[2].data).toEqual(join(box('moof', 2), box('mdat', 2)));
+        expect(out[1]!.data).toEqual(join(box('moof', 1), box('mdat', 1)));
+        expect(out[2]!.data).toEqual(join(box('moof', 2), box('mdat', 2)));
     });
 
     /*
@@ -52,8 +52,8 @@ describe('fMP4 を割る', () => {
         const out = [];
         for (const byte of whole) out.push(...splitter.feed(Uint8Array.of(byte)));
         expect(out.map((s) => s.kind)).toEqual(['init', 'media']);
-        expect(out[0].data).toEqual(join(box('ftyp'), box('moov')));
-        expect(out[1].data).toEqual(join(box('moof', 1), box('mdat', 1)));
+        expect(out[0]!.data).toEqual(join(box('ftyp'), box('moov')));
+        expect(out[1]!.data).toEqual(join(box('moof', 1), box('mdat', 1)));
     });
 
     /*
@@ -64,7 +64,7 @@ describe('fMP4 を割る', () => {
         const splitter = new Fmp4Splitter();
         const out = splitter.feed(join(box('ftyp'), box('moov'), box('moof'), box('sidx'), box('mdat')));
         expect(out.map((s) => s.kind)).toEqual(['init', 'media']);
-        expect(out[1].data).toEqual(join(box('moof'), box('sidx'), box('mdat')));
+        expect(out[1]!.data).toEqual(join(box('moof'), box('sidx'), box('mdat')));
     });
 
     /*

--- a/src/lib/ts/fmp4.ts
+++ b/src/lib/ts/fmp4.ts
@@ -55,10 +55,10 @@ export class Fmp4Splitter {
             if (this.buffer.length - at < size) break;
 
             const type = String.fromCharCode(
-                this.buffer[at + 4],
-                this.buffer[at + 5],
-                this.buffer[at + 6],
-                this.buffer[at + 7],
+                this.buffer[at + 4]!,
+                this.buffer[at + 5]!,
+                this.buffer[at + 6]!,
+                this.buffer[at + 7]!,
             );
             const box = this.buffer.slice(at, at + size);
             at += size;

--- a/src/lib/ts/logo-area.test.ts
+++ b/src/lib/ts/logo-area.test.ts
@@ -40,7 +40,7 @@ function make(count: number, logo: Rect | null, alpha: number, logoValue = 255, 
             for (let y = logo.y; y < logo.y + logo.height; y++) {
                 for (let x = logo.x; x < logo.x + logo.width; x++) {
                     const at = y * W + x;
-                    data[at] = Math.round(data[at] * (1 - alpha) + logoValue * alpha);
+                    data[at] = Math.round(data[at]! * (1 - alpha) + logoValue * alpha);
                 }
             }
         }

--- a/src/lib/ts/logo-area.ts
+++ b/src/lib/ts/logo-area.ts
@@ -111,7 +111,7 @@ function median(values: number[]): number {
     if (values.length === 0) return 0;
     values.sort((a, b) => a - b);
     const half = values.length >> 1;
-    return values.length % 2 === 0 ? (values[half - 1] + values[half]) / 2 : values[half];
+    return values.length % 2 === 0 ? (values[half - 1]! + values[half]!) / 2 : values[half]!;
 }
 
 /** 隅の範囲。`width`/`height` はコマの大きさ */
@@ -133,7 +133,7 @@ function medianImage(frames: Frame[], region: Rect, width: number): Float32Array
     for (let y = 0; y < region.height; y++) {
         for (let x = 0; x < region.width; x++) {
             const at = (region.y + y) * width + region.x + x;
-            for (let n = 0; n < frames.length; n++) scratch[n] = frames[n].data[at];
+            for (let n = 0; n < frames.length; n++) scratch[n] = frames[n]!.data[at]!;
             out[y * region.width + x] = median(scratch);
         }
     }
@@ -145,7 +145,7 @@ function edges(image: Float32Array, w: number, h: number): Float32Array {
     const out = new Float32Array(w * h);
     for (let y = 1; y < h - 1; y++) {
         for (let x = 1; x < w - 1; x++) {
-            const at = (xx: number, yy: number) => image[yy * w + xx];
+            const at = (xx: number, yy: number) => image[yy * w + xx]!;
             const gx =
                 -at(x - 1, y - 1) -
                 2 * at(x - 1, y) -
@@ -269,8 +269,9 @@ function padded(rect: Rect, width: number, height: number): Rect {
  * (実素材で、90秒ぶんだけ渡したときに実際に外しました)。
  */
 export function findLogoArea(frames: Frame[]): Rect | null {
-    if (frames.length < MIN_FRAMES) return null;
-    const { width, height } = frames[0];
+    const first = frames[0];
+    if (frames.length < MIN_FRAMES || first === undefined) return null;
+    const { width, height } = first;
     if (width <= 0 || height <= 0) return null;
     if (frames.some((frame) => frame.width !== width || frame.height !== height)) return null;
 
@@ -279,13 +280,13 @@ export function findLogoArea(frames: Frame[]): Rect | null {
         const strength = edges(medianImage(frames, region, width), region.width, region.height);
 
         const sorted = Array.from(strength).sort((a, b) => a - b);
-        const middle = sorted[Math.floor(sorted.length * 0.5)];
-        const limit = sorted[Math.floor(sorted.length * (1 - EDGE_TOP))];
+        const middle = sorted[Math.floor(sorted.length * 0.5)]!;
+        const limit = sorted[Math.floor(sorted.length * (1 - EDGE_TOP))]!;
         // ロゴを出していない隅では、上位 1% も中央値とたいして変わらない
         if (limit < EDGE_FLOOR || limit < middle * EDGE_RATIO) continue;
 
         const mask = new Uint8Array(strength.length);
-        for (let at = 0; at < strength.length; at++) mask[at] = strength[at] >= limit ? 1 : 0;
+        for (let at = 0; at < strength.length; at++) mask[at] = strength[at]! >= limit ? 1 : 0;
 
         const found = largestBlob(
             dilate(mask, region.width, region.height, DILATE),

--- a/src/lib/ts/logo-dsmcc.test.ts
+++ b/src/lib/ts/logo-dsmcc.test.ts
@@ -59,10 +59,10 @@ describe('parseLogoModule', () => {
             ]),
         );
         expect(logos).toHaveLength(1);
-        expect(logos[0].logoId).toBe(0x0011);
-        expect(logos[0].logoType).toBe(0x05);
+        expect(logos[0]!.logoId).toBe(0x0011);
+        expect(logos[0]!.logoType).toBe(0x05);
         // **どの局のロゴかはモジュール自身が持っている。** 地上波と違って SDT を待たない
-        expect(logos[0].services).toEqual([
+        expect(logos[0]!.services).toEqual([
             { networkId: 4, serviceId: 211 },
             { networkId: 4, serviceId: 212 },
         ]);
@@ -71,7 +71,7 @@ describe('parseLogoModule', () => {
          * (`withPalette`)、形が違うものは触らない決まりなので、この偽 PNG は
          * 素通りする。入れ直しそのものは logo-palette 側で見ている
          */
-        expect(logos[0].data).toEqual(PNG);
+        expect(logos[0]!.data).toEqual(PNG);
     });
 
     test('途中で切れていても、読めたぶんだけ返す', () => {
@@ -89,7 +89,7 @@ describe('DsmccLogoCollector', () => {
 
         const logos = collector.collected();
         expect(logos).toHaveLength(1);
-        expect(logos[0].services).toEqual([{ networkId: 4, serviceId: 211 }]);
+        expect(logos[0]!.services).toEqual([{ networkId: 4, serviceId: 211 }]);
     });
 
     test('名前の違うモジュールは拾わない', () => {

--- a/src/lib/ts/logo-dsmcc.ts
+++ b/src/lib/ts/logo-dsmcc.ts
@@ -50,7 +50,7 @@ function parseLogoEsPids(section: Uint8Array): { serviceId: number; pids: number
     for (const [, pid, info] of pmtStreams(section)) {
         for (const [tag, descriptor] of descriptors(info)) {
             if (tag !== DESC_STREAM_IDENTIFIER || descriptor.length < 1) continue;
-            if (LOGO_COMPONENT_TAGS.has(descriptor[0])) pids.push(pid);
+            if (LOGO_COMPONENT_TAGS.has(descriptor[0]!)) pids.push(pid);
         }
     }
     return { serviceId: u16(section, 3), pids };
@@ -77,15 +77,15 @@ export interface ModuleLogo {
  */
 export function parseLogoModule(data: Uint8Array): ModuleLogo[] {
     if (data.length < 3) return [];
-    const logoType = data[0];
+    const logoType = data[0]!;
     const count = u16(data, 1);
     let at = 3;
 
     const logos: ModuleLogo[] = [];
     for (let i = 0; i < count; i++) {
         if (at + 3 > data.length) break;
-        const logoId = ((data[at] & 0x01) << 8) | data[at + 1];
-        const serviceCount = data[at + 2];
+        const logoId = ((data[at]! & 0x01) << 8) | data[at + 1]!;
+        const serviceCount = data[at + 2]!;
         at += 3;
 
         const services: { networkId: number; serviceId: number }[] = [];

--- a/src/lib/ts/logo-palette.ts
+++ b/src/lib/ts/logo-palette.ts
@@ -68,7 +68,7 @@ const CRC_TABLE = (() => {
 
 function crc32(bytes: Uint8Array): number {
     let c = 0xffffffff;
-    for (const byte of bytes) c = CRC_TABLE[(c ^ byte) & 0xff] ^ (c >>> 8);
+    for (const byte of bytes) c = CRC_TABLE[(c ^ byte) & 0xff]! ^ (c >>> 8);
     return (c ^ 0xffffffff) >>> 0;
 }
 
@@ -114,10 +114,10 @@ export function withPalette(png: Uint8Array): Uint8Array {
     const rgb = new Uint8Array(COLORS * 3);
     const alpha = new Uint8Array(COLORS);
     for (let i = 0; i < COLORS; i++) {
-        rgb[i * 3] = CLUT[i * 4];
-        rgb[i * 3 + 1] = CLUT[i * 4 + 1];
-        rgb[i * 3 + 2] = CLUT[i * 4 + 2];
-        alpha[i] = CLUT[i * 4 + 3];
+        rgb[i * 3] = CLUT[i * 4]!;
+        rgb[i * 3 + 1] = CLUT[i * 4 + 1]!;
+        rgb[i * 3 + 2] = CLUT[i * 4 + 2]!;
+        alpha[i] = CLUT[i * 4 + 3]!;
     }
 
     const plte = pngChunk('PLTE', rgb);

--- a/src/lib/ts/logo.test.ts
+++ b/src/lib/ts/logo.test.ts
@@ -108,8 +108,8 @@ describe('拾い集める', () => {
         );
         const found = collector.collected();
         expect(found).toHaveLength(1);
-        expect(found[0].serviceIds.sort()).toEqual([1024, 1025]);
-        expect(found[0].logo.data).toEqual(PNG);
+        expect(found[0]!.serviceIds.sort()).toEqual([1024, 1025]);
+        expect(found[0]!.logo.data).toEqual(PNG);
     });
 
     test('対応だけあってロゴが来ていなければ配らない', () => {
@@ -124,7 +124,7 @@ describe('拾い集める', () => {
         collector.feed(packetize(0x0029, cdtSection(3, 0x02, small)));
         collector.feed(packetize(0x0029, cdtSection(3, 0x05, PNG)));
         collector.feed(packetize(0x0011, sdtWithLogo([[1024, 3]])));
-        expect(collector.collected()[0].logo.logoType).toBe(0x05);
+        expect(collector.collected()[0]!.logo.logoType).toBe(0x05);
     });
 
     test('小さいロゴが後から来ても戻さない', () => {
@@ -132,7 +132,7 @@ describe('拾い集める', () => {
         collector.feed(packetize(0x0029, cdtSection(3, 0x05, PNG)));
         collector.feed(packetize(0x0029, cdtSection(3, 0x02, Uint8Array.from([1, 2, 3]))));
         collector.feed(packetize(0x0011, sdtWithLogo([[1024, 3]])));
-        expect(collector.collected()[0].logo.logoType).toBe(0x05);
+        expect(collector.collected()[0]!.logo.logoType).toBe(0x05);
     });
 
     test('188の切れ目と無関係に届いても読める', () => {

--- a/src/lib/ts/logo.ts
+++ b/src/lib/ts/logo.ts
@@ -56,15 +56,15 @@ export function parseCdt(section: Uint8Array): LogoData | null {
     if (section[0] !== TABLE_CDT) return null;
     if (section[10] !== DATA_TYPE_LOGO) return null;
 
-    const descriptorsLength = ((section[11] & 0x0f) << 8) | section[12];
+    const descriptorsLength = ((section[11]! & 0x0f) << 8) | section[12]!;
     let at = 13 + descriptorsLength;
     const end = section.length - 4;
     if (at + 7 > end) return null;
 
-    const logoType = section[at];
-    const logoId = ((section[at + 1] & 0x01) << 8) | section[at + 2];
-    const logoVersion = ((section[at + 3] & 0x0f) << 8) | section[at + 4];
-    const size = (section[at + 5] << 8) | section[at + 6];
+    const logoType = section[at]!;
+    const logoId = ((section[at + 1]! & 0x01) << 8) | section[at + 2]!;
+    const logoVersion = ((section[at + 3]! & 0x0f) << 8) | section[at + 4]!;
+    const size = (section[at + 5]! << 8) | section[at + 6]!;
     at += 7;
     if (at + size > end) return null;
 
@@ -86,7 +86,7 @@ export function parseLogoLinks(section: Uint8Array): Map<number, number> {
             if (tag !== DESC_LOGO_TRANSMISSION || descriptor.length < 3) continue;
             const type = descriptor[0];
             if (type === 0x01 || type === 0x02) {
-                links.set(serviceId, ((descriptor[1] & 0x01) << 8) | descriptor[2]);
+                links.set(serviceId, ((descriptor[1]! & 0x01) << 8) | descriptor[2]!);
             }
         }
     }

--- a/src/lib/ts/mkv.ts
+++ b/src/lib/ts/mkv.ts
@@ -64,7 +64,7 @@ interface Header {
  */
 function vint(buffer: Uint8Array, at: number, keepMarker: boolean): { value: number; next: number } | null {
     if (at >= buffer.length) return null;
-    const first = buffer[at];
+    const first = buffer[at]!;
     if (first === 0) return null;
     let length = 1;
     while (length <= 8 && (first & (0x80 >> (length - 1))) === 0) length++;
@@ -75,7 +75,7 @@ function vint(buffer: Uint8Array, at: number, keepMarker: boolean): { value: num
     // 印を落とした桁が全部 1 なら「大きさは不明」。頭だけ書いて流す器で出てくる
     let allOnes = (first & mask) === mask;
     for (let i = 1; i < length; i++) {
-        value = value * 256 + buffer[at + i];
+        value = value * 256 + buffer[at + i]!;
         if (buffer[at + i] !== 0xff) allOnes = false;
     }
     if (!keepMarker && allOnes) return { value: UNKNOWN, next: at + length };
@@ -153,7 +153,7 @@ export class MkvSplitter {
         if (track === null || track.next + 3 > body.length) return null;
         const view = new DataView(body.buffer, body.byteOffset);
         const offset = view.getInt16(track.next);
-        const flags = body[track.next + 2];
+        const flags = body[track.next + 2]!;
         if ((flags & 0x06) !== 0) return null;
         return {
             at: ((this.base + offset) * this.scale) / 1_000_000,

--- a/src/lib/ts/psi.test.ts
+++ b/src/lib/ts/psi.test.ts
@@ -41,13 +41,13 @@ describe('セクションの解釈', () => {
         const parsed = parseNit(nitSection(0x7fe0, 6, [[0x0408, 0x0004, [[1024, 0x01]]]]));
         expect(parsed?.networkId).toBe(0x7fe0);
         expect(parsed?.remoteControlKeyId).toBe(6);
-        expect(parsed?.transportStreams[0].transportStreamId).toBe(0x0408);
-        expect(parsed?.transportStreams[0].services[0].serviceId).toBe(1024);
+        expect(parsed?.transportStreams[0]?.transportStreamId).toBe(0x0408);
+        expect(parsed?.transportStreams[0]?.services[0]?.serviceId).toBe(1024);
     });
 
     test('CRCが合わないセクションは捨てる', () => {
         const section = sdtSection(0x0408, 0x0004, [[1024, 0x01]]);
-        section[section.length - 1] ^= 0xff;
+        section[section.length - 1]! ^= 0xff;
         const reader = new ServiceReader();
         reader.feed(packetize(0x0011, section));
         expect(reader.transport).toBeNull();

--- a/src/lib/ts/psi.ts
+++ b/src/lib/ts/psi.ts
@@ -51,7 +51,7 @@ const CRC32_TABLE = (() => {
 export function crc32(data: Uint8Array): number {
     let crc = 0xffffffff;
     for (const byte of data) {
-        crc = (((crc << 8) >>> 0) ^ CRC32_TABLE[((crc >>> 24) ^ byte) & 0xff]) >>> 0;
+        crc = (((crc << 8) >>> 0) ^ CRC32_TABLE[((crc >>> 24) ^ byte) & 0xff]!) >>> 0;
     }
     return crc >>> 0;
 }
@@ -120,20 +120,20 @@ export class SectionAssembler {
     /** パケットを1つ食わせる。組み上がったセクションを返す */
     feed(packet: Uint8Array): Uint8Array[] {
         if (packet[0] !== SYNC) return [];
-        const pid = ((packet[1] & 0x1f) << 8) | packet[2];
+        const pid = ((packet[1]! & 0x1f) << 8) | packet[2]!;
         if (pid !== this.pid) return [];
         // トランスポートエラーが立っているものは信用しない
-        if (packet[1] & 0x80) return [];
+        if (packet[1]! & 0x80) return [];
 
-        const adaptation = (packet[3] >> 4) & 0x03;
+        const adaptation = (packet[3]! >> 4) & 0x03;
         if (adaptation === 0 || adaptation === 2) return [];
         let offset = 4;
-        if (adaptation === 3) offset += 1 + packet[4];
+        if (adaptation === 3) offset += 1 + packet[4]!;
         if (offset >= PACKET) return [];
 
         const payload = packet.subarray(offset);
-        if (packet[1] & 0x40) {
-            const pointer = payload[0];
+        if (packet[1]! & 0x40) {
+            const pointer = payload[0]!;
             if (1 + pointer > payload.length) return [];
             // pointer_field の手前は前のセクションの続き
             this.append(payload.subarray(1, 1 + pointer));
@@ -163,12 +163,12 @@ export class SectionAssembler {
                 this.buffer = new Uint8Array(0);
                 return sections;
             }
-            const length = 3 + (((this.buffer[1] & 0x0f) << 8) | this.buffer[2]);
+            const length = 3 + (((this.buffer[1]! & 0x0f) << 8) | this.buffer[2]!);
             if (this.buffer.length < length) return sections;
             const section = this.buffer.slice(0, length);
             this.buffer = this.buffer.slice(length);
             // 壊れたセクションを読むと嘘の局が並ぶので、CRC を通ったものだけ使う
-            const syntax = (section[1] & 0x80) !== 0;
+            const syntax = (section[1]! & 0x80) !== 0;
             if (this.crc === 'syntax' && !syntax) sections.push(section);
             else if (crc32(section) === 0) sections.push(section);
         }
@@ -231,8 +231,8 @@ export class PacketStream {
 export function* descriptors(data: Uint8Array): Generator<[number, Uint8Array]> {
     let at = 0;
     while (at + 2 <= data.length) {
-        const tag = data[at];
-        const length = data[at + 1];
+        const tag = data[at]!;
+        const length = data[at + 1]!;
         const body = data.subarray(at + 2, at + 2 + length);
         if (body.length < length) return;
         yield [tag, body];
@@ -245,7 +245,7 @@ export function* descriptors(data: Uint8Array): Generator<[number, Uint8Array]> 
  */
 export function pmtProgramInfo(section: Uint8Array): Uint8Array {
     if (section[0] !== TABLE_PMT || section.length < 16) return new Uint8Array(0);
-    const length = ((section[10] & 0x0f) << 8) | section[11];
+    const length = ((section[10]! & 0x0f) << 8) | section[11]!;
     return section.subarray(12, 12 + length);
 }
 
@@ -262,13 +262,13 @@ export function pmtProgramInfo(section: Uint8Array): Uint8Array {
  */
 export function* pmtStreams(section: Uint8Array): Generator<[number, number, Uint8Array]> {
     if (section[0] !== TABLE_PMT || section.length < 16) return;
-    const programInfoLength = ((section[10] & 0x0f) << 8) | section[11];
+    const programInfoLength = ((section[10]! & 0x0f) << 8) | section[11]!;
     let at = 12 + programInfoLength;
     const end = section.length - 4;
     while (at + 5 <= end) {
-        const pid = ((section[at + 1] & 0x1f) << 8) | section[at + 2];
-        const infoLength = ((section[at + 3] & 0x0f) << 8) | section[at + 4];
-        yield [section[at], pid, section.subarray(at + 5, at + 5 + infoLength)];
+        const pid = ((section[at + 1]! & 0x1f) << 8) | section[at + 2]!;
+        const infoLength = ((section[at + 3]! & 0x0f) << 8) | section[at + 4]!;
+        yield [section[at]!, pid, section.subarray(at + 5, at + 5 + infoLength)];
         at += 5 + infoLength;
     }
 }
@@ -279,9 +279,9 @@ export function parsePat(section: Uint8Array): Map<number, number> {
     if (section[0] !== TABLE_PAT) return programs;
     const end = section.length - 4;
     for (let at = 8; at + 4 <= end; at += 4) {
-        const serviceId = (section[at] << 8) | section[at + 1];
+        const serviceId = (section[at]! << 8) | section[at + 1]!;
         if (serviceId === 0) continue;
-        programs.set(serviceId, ((section[at + 2] & 0x1f) << 8) | section[at + 3]);
+        programs.set(serviceId, ((section[at + 2]! & 0x1f) << 8) | section[at + 3]!);
     }
     return programs;
 }
@@ -296,8 +296,8 @@ export function* sdtServices(section: Uint8Array): Generator<[number, Uint8Array
     let at = 11;
     const end = section.length - 4;
     while (at + 5 <= end) {
-        const serviceId = (section[at] << 8) | section[at + 1];
-        const loop = ((section[at + 3] & 0x0f) << 8) | section[at + 4];
+        const serviceId = (section[at]! << 8) | section[at + 1]!;
+        const loop = ((section[at + 3]! & 0x0f) << 8) | section[at + 4]!;
         yield [serviceId, section.subarray(at + 5, at + 5 + loop)];
         at += 5 + loop;
     }
@@ -321,7 +321,7 @@ export function parseSdt(section: Uint8Array): TransportInfo | null {
                 const nameLength = descriptor[nameAt] ?? 0;
                 services.push({
                     serviceId,
-                    serviceType: descriptor[0],
+                    serviceType: descriptor[0]!,
                     name: decodeAribText(descriptor.subarray(nameAt + 1, nameAt + 1 + nameLength)),
                 });
                 break;
@@ -330,8 +330,8 @@ export function parseSdt(section: Uint8Array): TransportInfo | null {
     }
 
     return {
-        transportStreamId: (section[3] << 8) | section[4],
-        originalNetworkId: (section[8] << 8) | section[9],
+        transportStreamId: (section[3]! << 8) | section[4]!,
+        originalNetworkId: (section[8]! << 8) | section[9]!,
         services,
     };
 }
@@ -340,7 +340,7 @@ export function parseSdt(section: Uint8Array): TransportInfo | null {
 export function parseNit(section: Uint8Array): NetworkInfo | null {
     if (section[0] !== TABLE_NIT_ACTUAL) return null;
 
-    const networkLength = ((section[8] & 0x0f) << 8) | section[9];
+    const networkLength = ((section[8]! & 0x0f) << 8) | section[9]!;
     let at = 10 + networkLength;
     if (at + 2 > section.length) return null;
     at += 2; // transport_stream_loop_length
@@ -349,21 +349,21 @@ export function parseNit(section: Uint8Array): NetworkInfo | null {
     const transportStreams: TransportInfo[] = [];
     const end = section.length - 4;
     while (at + 6 <= end) {
-        const transportStreamId = (section[at] << 8) | section[at + 1];
-        const originalNetworkId = (section[at + 2] << 8) | section[at + 3];
-        const loop = ((section[at + 4] & 0x0f) << 8) | section[at + 5];
+        const transportStreamId = (section[at]! << 8) | section[at + 1]!;
+        const originalNetworkId = (section[at + 2]! << 8) | section[at + 3]!;
+        const loop = ((section[at + 4]! & 0x0f) << 8) | section[at + 5]!;
         const body = section.subarray(at + 6, at + 6 + loop);
         at += 6 + loop;
 
         const services: Service[] = [];
         for (const [tag, descriptor] of descriptors(body)) {
             if (tag === DESC_TS_INFORMATION && descriptor.length > 0 && remoteControlKeyId === null) {
-                remoteControlKeyId = descriptor[0];
+                remoteControlKeyId = descriptor[0]!;
             } else if (tag === DESC_SERVICE_LIST) {
                 for (let i = 0; i + 3 <= descriptor.length; i += 3) {
                     services.push({
-                        serviceId: (descriptor[i] << 8) | descriptor[i + 1],
-                        serviceType: descriptor[i + 2],
+                        serviceId: (descriptor[i]! << 8) | descriptor[i + 1]!,
+                        serviceType: descriptor[i + 2]!,
                         name: '',
                     });
                 }
@@ -372,7 +372,7 @@ export function parseNit(section: Uint8Array): NetworkInfo | null {
         transportStreams.push({ transportStreamId, originalNetworkId, services });
     }
 
-    return { networkId: (section[3] << 8) | section[4], remoteControlKeyId, transportStreams };
+    return { networkId: (section[3]! << 8) | section[4]!, remoteControlKeyId, transportStreams };
 }
 
 export interface FoundService extends Service {

--- a/src/lib/ts/service-filter.test.ts
+++ b/src/lib/ts/service-filter.test.ts
@@ -61,7 +61,7 @@ const pmt2 = () =>
 function pids(data: Uint8Array): number[] {
     const out: number[] = [];
     for (let at = 0; at + PACKET <= data.length; at += PACKET) {
-        out.push(((data[at + 1] & 0x1f) << 8) | data[at + 2]);
+        out.push(((data[at + 1]! & 0x1f) << 8) | data[at + 2]!);
     }
     return out;
 }
@@ -129,9 +129,9 @@ describe('局の選り分け', () => {
         const section = out.subarray(5, 5 + 20);
         expect(section[0]).toBe(0x00);
         const programs: number[] = [];
-        const length = ((section[1] & 0x0f) << 8) | section[2];
+        const length = ((section[1]! & 0x0f) << 8) | section[2]!;
         for (let at = 8; at + 4 <= 3 + length - 4; at += 4) {
-            programs.push((section[at] << 8) | section[at + 1]);
+            programs.push((section[at]! << 8) | section[at + 1]!);
         }
         // 0 は NIT の枠。局は MX1 だけ
         expect(programs).toEqual([0, MX1]);

--- a/src/lib/ts/service-filter.ts
+++ b/src/lib/ts/service-filter.ts
@@ -137,13 +137,13 @@ export class ServiceFilter {
         let length = 0;
 
         for (const ts of this.packets.feed(chunk)) {
-            const pid = ((ts[1] & 0x1f) << 8) | ts[2];
+            const pid = ((ts[1]! & 0x1f) << 8) | ts[2]!;
             if (pid === PID_NULL) continue;
 
             if (pid === PID_PAT) {
                 this.readPat(ts);
                 // 元の PAT は捨てて、書き直したものを同じ回数だけ出す
-                if (this.rewritten !== null && (ts[1] & 0x40) !== 0) {
+                if (this.rewritten !== null && (ts[1]! & 0x40) !== 0) {
                     out.push(packet(PID_PAT, this.rewritten, this.counter++));
                     length += PACKET;
                 }
@@ -175,13 +175,13 @@ export class ServiceFilter {
     private readPat(ts: Uint8Array): void {
         for (const section of this.pat.feed(ts)) {
             if (section[0] !== TABLE_PAT) continue;
-            const transportStreamId = (section[3] << 8) | section[4];
+            const transportStreamId = (section[3]! << 8) | section[4]!;
             this.tsid = transportStreamId;
-            const version = (section[5] >> 1) & 0x1f;
+            const version = (section[5]! >> 1) & 0x1f;
             for (let at = 8; at + 4 <= section.length - 4; at += 4) {
-                const programNumber = (section[at] << 8) | section[at + 1];
+                const programNumber = (section[at]! << 8) | section[at + 1]!;
                 if (programNumber !== this.serviceId) continue;
-                const pmtPid = ((section[at + 2] & 0x1f) << 8) | section[at + 3];
+                const pmtPid = ((section[at + 2]! & 0x1f) << 8) | section[at + 3]!;
                 if (pmtPid === this.pmtPid) return;
                 // 選局し直した・PAT が入れ替わった。PMT も読み直す
                 this.pmtPid = pmtPid;
@@ -199,7 +199,7 @@ export class ServiceFilter {
             const pids = new Set<number>();
 
             // PCR。映像と同じ PID のことが多いが、別に振られていることもある
-            const pcrPid = ((section[8] & 0x1f) << 8) | section[9];
+            const pcrPid = ((section[8]! & 0x1f) << 8) | section[9]!;
             if (pcrPid !== 0x1fff) pids.add(pcrPid);
 
             collectCa(pmtProgramInfo(section), pids);
@@ -219,9 +219,9 @@ function collectCa(body: Uint8Array, into: Set<number>): void {
     let at = 0;
     while (at + 2 <= body.length) {
         const tag = body[at];
-        const length = body[at + 1];
+        const length = body[at + 1]!;
         if (tag === DESC_CA && length >= 4) {
-            into.add(((body[at + 4] & 0x1f) << 8) | body[at + 5]);
+            into.add(((body[at + 4]! & 0x1f) << 8) | body[at + 5]!);
         }
         at += 2 + length;
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -725,6 +725,8 @@
                         {@const link = watchLink(rec)}
                         {@const canPlay = link !== null}
                         {@const shown = rowState(rec)}
+                        <!-- 端末に入っているか (オフライン視聴)。行の印と、下のバーで見る -->
+                        {@const held = offline.entries[rec.id]}
                         <!--
                             押すと再生。中身を読みたいときは行の中の「詳細」から。
 
@@ -803,8 +805,7 @@
                                         決まるので、ここで書き分けることは何も無い
                                     -->
                                     {@render title(shown.label, shown.badge, rec.name, 'recording-state')}
-                                    {#if offline.entries[rec.id] !== undefined}
-                                        {@const held = offline.entries[rec.id]}
+                                    {#if held !== undefined}
                                         <!-- 端末に入っている印。保存中はエンコードと同じく割合を添える -->
                                         <span
                                             class="badge badge-sm mt-1 {held.state === 'ready'
@@ -1051,7 +1052,7 @@
                                 <!-- 端末への保存もエンコードと同じ見せ方。測れない間は動くだけのバー -->
                                 <progress
                                     class="progress progress-success absolute inset-x-0 bottom-0 h-1 w-full rounded-none"
-                                    value={offline.entries[rec.id].progress ?? undefined}
+                                    value={offline.entries[rec.id]?.progress ?? undefined}
                                     max="1"
                                     data-testid="offline-bar"
                                 ></progress>
@@ -1134,7 +1135,7 @@
                     ので出さない。保存済みなら「端末から消す」に変わる —
                     こちらはサーバの録画に触らない (行の削除ボタンとは別)
                 -->
-                {#if offline.entries[rec.id] === undefined || offline.entries[rec.id].state === 'failed'}
+                {#if offline.entries[rec.id] === undefined || offline.entries[rec.id]?.state === 'failed'}
                     <button
                         type="button"
                         class="btn btn-outline"
@@ -1144,7 +1145,8 @@
                         {offline.entries[rec.id]?.state === 'failed' ? '保存をやり直す' : '端末に保存'}
                     </button>
                 {/if}
-                {#if offline.entries[rec.id] !== undefined}
+                {@const held = offline.entries[rec.id]}
+                {#if held !== undefined}
                     <button
                         type="button"
                         class="btn btn-outline"
@@ -1154,9 +1156,9 @@
                         }}
                         data-testid="offline-remove-button"
                     >
-                        {offline.entries[rec.id].state === 'downloading'
+                        {held.state === 'downloading'
                             ? '保存を取り消す'
-                            : offline.entries[rec.id].state === 'failed'
+                            : held.state === 'failed'
                               ? '失敗した保存データを消す'
                               : '端末から消す'}
                     </button>

--- a/src/routes/api/recordings/[id]/frame/+server.ts
+++ b/src/routes/api/recordings/[id]/frame/+server.ts
@@ -43,7 +43,7 @@ async function sourceSize(input: string): Promise<{ width: number; height: numbe
         ],
         { timeoutMs: TIMEOUT, stdout: true },
     );
-    const [width, height] = new TextDecoder().decode(probed.stdout).trim().split(',').map(Number);
+    const [width = NaN, height = NaN] = new TextDecoder().decode(probed.stdout).trim().split(',').map(Number);
     if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0) return null;
     return { width, height };
 }

--- a/src/routes/live/+page.svelte
+++ b/src/routes/live/+page.svelte
@@ -405,7 +405,7 @@
                         できないものをできる顔で出さないために、d ボタンと同じ
                         形にはせず「外へ出ていく」印にしてあります
                     -->
-                        {#if player.hybridcast.length > 0}
+                        {#if player.hybridcast[0] !== undefined}
                             {@const app = player.hybridcast[0]}
                             <ControlButton
                                 path={OPEN_OUT}

--- a/src/routes/watch/[id]/+page.svelte
+++ b/src/routes/watch/[id]/+page.svelte
@@ -546,8 +546,10 @@
         const list: { label: string }[] = [];
         let enabled = 0;
         for (let i = 0; i < tracks.length; i++) {
-            list.push({ label: audioLabel(tracks[i], i) });
-            if (tracks[i].enabled) enabled = i;
+            const track = tracks[i];
+            if (track === undefined) continue;
+            list.push({ label: audioLabel(track, i) });
+            if (track.enabled) enabled = i;
         }
         audios = list;
         audioIndex = enabled;
@@ -557,7 +559,10 @@
     function selectAudio(index: number): void {
         const tracks = audioTrackList();
         if (tracks === null) return;
-        for (let i = 0; i < tracks.length; i++) tracks[i].enabled = i === index;
+        for (let i = 0; i < tracks.length; i++) {
+            const track = tracks[i];
+            if (track !== undefined) track.enabled = i === index;
+        }
         audioIndex = index;
     }
 

--- a/tests/e2e/02-reservation.spec.ts
+++ b/tests/e2e/02-reservation.spec.ts
@@ -163,7 +163,7 @@ test.describe('予約の細かい指定', () => {
         await goto(page, '/guide?type=GR');
         const done = await past(page);
 
-        await cellOf(page, done[0].programId).getByTestId('program-button').click();
+        await cellOf(page, done[0]!.programId).getByTestId('program-button').click();
         const detail = page.getByTestId('program-detail');
         await expect(detail).toBeVisible();
         await expect(detail.getByTestId('detail-ended')).toHaveText('放送終了');
@@ -173,7 +173,7 @@ test.describe('予約の細かい指定', () => {
 
         await goto(page, '/');
         await expect(
-            page.locator(`[data-testid="reservation-row"][data-program-id="${done[0].programId}"]`),
+            page.locator(`[data-testid="reservation-row"][data-program-id="${done[0]!.programId}"]`),
         ).toHaveCount(0);
     });
 });
@@ -258,7 +258,7 @@ test.describe('番組表のマスを押す', () => {
         const box = (await cell.boundingBox()) ?? { x: 0, y: 0, width: 0, height: 0 };
 
         await page.evaluate(
-            ([x, y]) => {
+            ({ x, y }) => {
                 const at = (cx: number, cy: number) => ({
                     pointerId: 1,
                     pointerType: 'touch',
@@ -275,7 +275,7 @@ test.describe('番組表のマスを押す', () => {
                 target.dispatchEvent(new PointerEvent('pointerup', at(x + 6, y)));
                 (target as HTMLElement).closest('button')?.click();
             },
-            [box.x + box.width / 2, box.y + box.height / 2],
+            { x: box.x + box.width / 2, y: box.y + box.height / 2 },
         );
 
         await expect(page.getByTestId('program-detail')).toBeVisible();

--- a/tests/e2e/03-recording.spec.ts
+++ b/tests/e2e/03-recording.spec.ts
@@ -182,7 +182,7 @@ test.describe('CMの実カット', () => {
 
         await goto(page, '/guide?type=BS');
         const cells = await upcoming(page);
-        const target = cells[0];
+        const target = cells[0]!;
         const res = await request.post('/guide?/reserve', {
             form: { programId: target.programId, options: '1', encode: 'on' },
         });

--- a/tests/e2e/09-behaviour.spec.ts
+++ b/tests/e2e/09-behaviour.spec.ts
@@ -144,7 +144,7 @@ test.describe('操作したときの反応', () => {
                 length: (node.textContent ?? '').length,
             })),
         );
-        const target = cells.sort((a, b) => b.length - a.length)[0];
+        const target = cells.sort((a, b) => b.length - a.length)[0]!;
         await cellOf(page, target.id).getByTestId('program-button').click();
 
         const detail = page.getByTestId('program-detail');

--- a/tests/e2e/15-scramble.spec.ts
+++ b/tests/e2e/15-scramble.spec.ts
@@ -10,7 +10,7 @@ function scrambledFiles(dir: string): string[] {
             const buffer = readFileSync(join(dir, name));
             for (let i = 0; i + 188 <= buffer.length; i += 188) {
                 if (buffer[i] !== 0x47) return false;
-                if ((buffer[i + 3] & 0xc0) !== 0) return true;
+                if ((buffer[i + 3]! & 0xc0) !== 0) return true;
             }
             return false;
         });

--- a/tests/e2e/18-pwa.spec.ts
+++ b/tests/e2e/18-pwa.spec.ts
@@ -50,7 +50,7 @@ test.describe('PWA', () => {
         // 指紋が付いているものは、変わっていなければ中身を流さない
         const first = await request.get('/');
         const again = await request.get('/', {
-            headers: { 'if-none-match': first.headers()['etag'] },
+            headers: { 'if-none-match': first.headers()['etag'] ?? '' },
         });
         expect(again.status()).toBe(304);
 

--- a/tests/e2e/20-live.spec.ts
+++ b/tests/e2e/20-live.spec.ts
@@ -34,15 +34,15 @@ function patPrograms(data: Buffer): number[] {
     const found: number[] = [];
     for (let at = 0; at + 188 <= data.length; at += 188) {
         if (data[at] !== 0x47) continue;
-        const pid = ((data[at + 1] & 0x1f) << 8) | data[at + 2];
+        const pid = ((data[at + 1]! & 0x1f) << 8) | data[at + 2]!;
         // 区切りの頭が入っているものだけ (payload_unit_start_indicator)
-        if (pid !== 0 || (data[at + 1] & 0x40) === 0) continue;
-        const start = at + 4 + 1 + data[at + 4];
+        if (pid !== 0 || (data[at + 1]! & 0x40) === 0) continue;
+        const start = at + 4 + 1 + data[at + 4]!;
         if (data[start] !== 0x00) continue;
-        const length = ((data[start + 1] & 0x0f) << 8) | data[start + 2];
+        const length = ((data[start + 1]! & 0x0f) << 8) | data[start + 2]!;
         const end = start + 3 + length - 4;
         for (let i = start + 8; i + 4 <= end && i + 4 <= at + 188; i += 4) {
-            const program = (data[i] << 8) | data[i + 1];
+            const program = (data[i]! << 8) | data[i + 1]!;
             // 0 は NIT で局ではない
             if (program !== 0) found.push(program);
         }
@@ -579,7 +579,7 @@ test.describe('ライブ視聴', () => {
         await expect(channels.first()).toBeVisible();
 
         // 局は名前ではなくIDで指す。名前は SDT 由来で、表示のしかたに引きずられる
-        const mx = page.locator(`[data-testid=live-channel][data-service="${SERVICES[0].id}"]`);
+        const mx = page.locator(`[data-testid=live-channel][data-service="${SERVICES[0]!.id}"]`);
         await mx.click();
         await expect(page.getByTestId('live-title')).toBeVisible();
 
@@ -599,7 +599,7 @@ test.describe('ライブ視聴', () => {
         ]);
 
         // 載せていない局に移ると消える。**前の局のぶんを出したままにしない**
-        const other = page.locator(`[data-testid=live-channel][data-service="${SERVICES[1].id}"]`);
+        const other = page.locator(`[data-testid=live-channel][data-service="${SERVICES[1]!.id}"]`);
         await other.click();
         await expect(page.getByTestId('live-title')).toBeVisible();
         await expect(button).toBeHidden();

--- a/tests/e2e/22-oidc.spec.ts
+++ b/tests/e2e/22-oidc.spec.ts
@@ -52,7 +52,7 @@ function client(oidc: OidcStack, { xff = OUTSIDE, host = 'denpa.test' } = {}) {
         if (jar.size > 0) headers['cookie'] = [...jar].map(([k, v]) => `${k}=${v}`).join('; ');
         const res = await fetch(`${oidc.appUrl}${path}`, { ...init, headers, redirect: 'manual' });
         for (const raw of res.headers.getSetCookie?.() ?? []) {
-            const [pair] = raw.split(';');
+            const [pair = ''] = raw.split(';');
             const at = pair.indexOf('=');
             const name = pair.slice(0, at).trim();
             const value = pair.slice(at + 1).trim();

--- a/tests/e2e/22-watch.spec.ts
+++ b/tests/e2e/22-watch.spec.ts
@@ -118,7 +118,7 @@ test.describe('録画を観る', () => {
         const sup = await res.body();
         // PGS の節は 'PG' で始まる
         expect(sup.length).toBeGreaterThan(0);
-        expect(String.fromCharCode(sup[0], sup[1])).toBe('PG');
+        expect(String.fromCharCode(sup[0]!, sup[1]!)).toBe('PG');
 
         await goto(page, `/watch/${id}`);
         // 重ねる先は映像と同じ枠に敷いてある。**押す邪魔をしない**

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -80,7 +80,14 @@ export async function past(page: Page): Promise<Cell[]> {
  * 偽の放送は隙間なく並べてある (`tests/fake/broadcast.ts`) ので、始まったものの
  * うちいちばん新しいものがそれにあたる。終わりの時刻はマスに出ていない
  */
-export async function airing(page: Page): Promise<Cell[]> {
+/** 1つは要る。型でも「先頭がある」と言う (`const [target] = await upcoming(page)` がそのまま使える) */
+function atLeastOne(cells: Cell[], what: string): [Cell, ...Cell[]] {
+    const [head, ...rest] = cells;
+    if (head === undefined) throw new Error(`${what}が1つも無い`);
+    return [head, ...rest];
+}
+
+export async function airing(page: Page): Promise<[Cell, ...Cell[]]> {
     const at = Date.now();
     const latest = new Map<string, Cell>();
     for (const cell of await allCells(page)) {
@@ -88,12 +95,10 @@ export async function airing(page: Page): Promise<Cell[]> {
         const held = latest.get(cell.serviceId);
         if (held === undefined || cell.startAt > held.startAt) latest.set(cell.serviceId, cell);
     }
-    const found = [...latest.values()];
-    expect(found.length).toBeGreaterThan(0);
-    return found;
+    return atLeastOne([...latest.values()], 'いま流れている番組');
 }
 
-export async function upcoming(page: Page): Promise<Cell[]> {
+export async function upcoming(page: Page): Promise<[Cell, ...Cell[]]> {
     let soon = await cellsOn(page);
     if (soon.length === 0) {
         // 放送日の終わり際(深夜3時台など)は、この日にこれから始まる番組が
@@ -102,8 +107,7 @@ export async function upcoming(page: Page): Promise<Cell[]> {
         await page.locator('[data-hydrated="true"]').waitFor();
         soon = await cellsOn(page);
     }
-    expect(soon.length).toBeGreaterThan(0);
-    return soon;
+    return atLeastOne(soon, 'これから始まる番組');
 }
 
 /** 番組表のマスをIDで掴む。番組が終わると並びがずれるので位置では追わない */
@@ -120,7 +124,7 @@ export function cellOf(page: Page, programId: string) {
 export async function reserveSoon(page: Page, request: APIRequestContext, type: string, skip = 0) {
     await goto(page, `/guide?type=${type}`);
     const cells = await upcoming(page);
-    const target = cells[Math.min(skip, cells.length - 1)];
+    const target = cells[Math.min(skip, cells.length - 1)]!;
     const res = await request.post('/guide?/reserve', { form: { programId: target.programId } });
     await ok(res, '予約');
     return target.programId;

--- a/tests/fake/agent.ts
+++ b/tests/fake/agent.ts
@@ -42,7 +42,7 @@ function unscramble(root: string, input: string, output: string): { ok: boolean;
     if (!existsSync(from)) return { ok: false, error: `${from} が見えません` };
 
     const buffer = readFileSync(from);
-    for (let i = 0; i + 188 <= buffer.length; i += 188) buffer[i + 3] &= 0x3f;
+    for (let i = 0; i + 188 <= buffer.length; i += 188) buffer[i + 3]! &= 0x3f;
     writeFileSync(to, buffer);
     return { ok: true, error: '' };
 }

--- a/tests/fake/broadcast.ts
+++ b/tests/fake/broadcast.ts
@@ -247,7 +247,7 @@ const ENGINEERING = { service: 929, pmt: 0x1f0, es: 0x1f1 };
 function carouselPackets(services: FakeService[]): Uint8Array {
     const module = logoModule(0x05, [
         {
-            logoId: services[0].serviceId % 512,
+            logoId: services[0]!.serviceId % 512,
             services: services.map((s) => [s.networkId, s.serviceId] as [number, number]),
             data: LOGO_PNG,
         },
@@ -366,7 +366,7 @@ export function tables(services: FakeService[]): Uint8Array {
         }
     }
 
-    const first = services[0];
+    const first = services[0]!;
     parts.push(
         ...packetize(
             0x0011,

--- a/tests/fake/services.ts
+++ b/tests/fake/services.ts
@@ -102,8 +102,8 @@ export const SERVICES: FakeService[] = [
     },
 ];
 
-export const MX = SERVICES[0];
-export const FUJI = SERVICES[1];
-export const DATA = SERVICES[2];
-export const BS11 = SERVICES[3];
-export const BS_NO_LOGO = SERVICES[4];
+export const MX = SERVICES[0]!;
+export const FUJI = SERVICES[1]!;
+export const DATA = SERVICES[2]!;
+export const BS11 = SERVICES[3]!;
+export const BS_NO_LOGO = SERVICES[4]!;

--- a/tests/stack.ts
+++ b/tests/stack.ts
@@ -70,8 +70,9 @@ interface Started {
     output: () => string;
 }
 
-function start(command: string[], env: Record<string, string>): Started {
-    const proc = spawn(command[0], command.slice(1), {
+function start(command: [string, ...string[]], env: Record<string, string>): Started {
+    const [bin, ...args] = command;
+    const proc = spawn(bin, args, {
         env: { ...process.env, ...env },
         stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "noImplicitOverride": true,
         "exactOptionalPropertyTypes": true,
         "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
         "moduleResolution": "bundler",
         "types": ["bun"]
     }


### PR DESCRIPTION
## 何を

tsconfig に `noUncheckedIndexedAccess` を足し、出た 560 箇所を直しました (#41 → #43 → #44 の続きで、これで型の締め付けは一区切りです)。

## 書き分け

`docs/development.md` に「型の締め方」として書きました。

- **バイト列の読み** (`src/lib/ts/` の TS / PSI / EIT / PGS / DSM-CC / AIT / ロゴの読み手、約 300 箇所) は、長さを確かめた上で `data[i]!`。1 バイトごとに undefined を見ると読み手が二倍の長さになるだけで、長さの確認は既にあります。この形は**機械的に付けました** — TypeScript の診断の範囲が添字の式そのものに一致するところだけに `!` を足す codemod で、判断の要る場所 (診断が別の式に出るもの) は手で見ています。
- **配列の先頭・regex の group・`split()` の結果** は undefined を見ます (`?? ''`、`const [a = NaN] = ...`、`if (x === undefined) return`)。手で直したのは:
  - `encoder.ts`: 焼いたものの置き場を決めるところ。空なら理由を言って止まる (前は `placed[0].path` で TypeError)
  - `oidc.ts`: ID トークンの 3 分割を undefined 込みで確かめる
  - `+page.svelte`: `offline.entries[rec.id]` は `{@const held}` を行の頭で 1 回引き、`held !== undefined` で見る (前は `[rec.id].state` を 5 箇所で直に読んでいた)
  - `live/+page.svelte`: Hybridcast の先頭を `player.hybridcast[0] !== undefined` で
  - `watch/+page.svelte`: `AudioTrackList` の添字
  - `settings.ts` / `format.ts` / `logo-data.ts` / `scan.ts` / `auth.ts` / `cm.ts` / `frame/+server.ts` など、先頭や分割の結果を読むところ
- **e2e の `upcoming()` / `airing()`** は `[Cell, ...Cell[]]` を返し、空なら理由を言って止まります。`const [target] = await upcoming(page)` がそのまま `Cell` になります。`tests/fake/services.ts` の `MX` / `BS11` などは `!`。
- **試験** は `!` でよい (落ちれば試験が落ちる)。biome の `noNonNullAssertedOptionalChain` に当たる `a?.b[0]!.c` は `a?.b[0]?.c` に。

## 確かめたこと

- `biome check .` / `svelte-check` 0 エラー
- 単体 793 本
- e2e 全体

🤖 Generated with [Claude Code](https://claude.com/claude-code)
