### PR TITLE
refactor: 外から来る JSON は形を確かめてから型にする (lib/shape.ts)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -116,8 +116,12 @@ JSON で持つ列 (ジャンル・音声の構成・ルールの対象チャン�
 
 外から来る JSON (チューナーエージェントの答え、OIDC の相手、取り込み元の DB) は
 `res.json() as X` と書かず、`src/lib/shape.ts` の読み手で形を確かめてから型にする
-(`read(array(AGENT_CHANNEL), await res.json(), 'エージェントの /denpa/channels')`)。型は形から
-導く (`Infer<typeof AGENT_CHANNEL>`) ので、形と型を別々に書かない。自分のサーバから自分の画面へ
+(`tolerate(array(AGENT_CHANNEL), await res.json(), 'エージェントの /denpa/channels')`)。型は形から
+導く (`Infer<typeof AGENT_CHANNEL>`) ので、形と型を別々に書かない。
+
+読み方は 2 つ。**`tolerate`** は形が違っても止めず、警告を 1 回出して来たものをそのまま使う
+(エージェントの答え — 版がずれただけで録画が止まるのでは困る)。**`read`** は止める
+(ID トークン — 違う形のまま進むと危ない)。迷ったら `tolerate`。自分のサーバから自分の画面へ
 渡すもの (同じリポジトリの中) はキャストのままでよい。
 
 **マイグレーションを持つ前の DB** (1.7.x まで。`CREATE TABLE IF NOT EXISTS` を起動のたびに

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,6 +114,12 @@ JSON で持つ列 (ジャンル・音声の構成・ルールの対象チャン�
   空でないことを確かめている (`atLeastOne` のような) 場合だけ
 - **試験** は `!` でよい。落ちれば試験が落ちる
 
+外から来る JSON (チューナーエージェントの答え、OIDC の相手、取り込み元の DB) は
+`res.json() as X` と書かず、`src/lib/shape.ts` の読み手で形を確かめてから型にする
+(`read(array(AGENT_CHANNEL), await res.json(), 'エージェントの /denpa/channels')`)。型は形から
+導く (`Infer<typeof AGENT_CHANNEL>`) ので、形と型を別々に書かない。自分のサーバから自分の画面へ
+渡すもの (同じリポジトリの中) はキャストのままでよい。
+
 **マイグレーションを持つ前の DB** (1.7.x まで。`CREATE TABLE IF NOT EXISTS` を起動のたびに
 流して整えていた) には、最初のマイグレーション (baseline) を `IF NOT EXISTS` にしてあるので
 そのまま当たる。1.7.x を一度も起動していない古い DB は列が足りないことがあり、起動時に

--- a/src/lib/server/migrate.ts
+++ b/src/lib/server/migrate.ts
@@ -15,6 +15,7 @@ import { dirname, join } from 'node:path';
 import { SQL } from 'bun';
 import { and, eq, isNull } from 'drizzle-orm';
 import { parseSearchFields, SEARCH_FIELDS } from '$lib/search';
+import { array, number, read } from '$lib/shape';
 import { now, orm } from './db';
 import { emit } from './events';
 import { libraryPath, recordedPath } from './library';
@@ -390,7 +391,7 @@ async function importRules(connection: SQL, options: MigrateOptions): Promise<vo
         let channels: number[] = [];
         if (row.channelIds !== null) {
             try {
-                channels = (JSON.parse(row.channelIds) as number[])
+                channels = read(array(number), JSON.parse(row.channelIds), 'EPGStation の channelIds')
                     .map(serviceIdFor)
                     .filter((id): id is number => id !== undefined);
             } catch {

--- a/src/lib/server/oidc.ts
+++ b/src/lib/server/oidc.ts
@@ -11,6 +11,7 @@
  * **ここは「誰か」を確かめるだけ**で、通すかどうかは `auth.ts` が決めます。
  */
 
+import { array, either, type Infer, number, object, optional, read, record, string } from '../shape';
 import { config } from './config';
 
 /** 有効かどうか。3つ揃っていなければ、入る道は TRUSTED_NETWORKS だけ (auth.ts) */
@@ -18,13 +19,15 @@ export function enabled(): boolean {
     return config.oidcIssuer !== '' && config.oidcClientId !== '' && config.oidcClientSecret !== '';
 }
 
-export interface Discovery {
-    issuer: string;
-    authorization_endpoint: string;
-    token_endpoint: string;
-    jwks_uri: string;
-    end_session_endpoint?: string;
-}
+/** 相手の口の一覧 (`/.well-known/openid-configuration`)。形はここで確かめる (`shape.ts`) */
+const DISCOVERY = object({
+    issuer: string,
+    authorization_endpoint: string,
+    token_endpoint: string,
+    jwks_uri: string,
+    end_session_endpoint: optional(string),
+});
+export type Discovery = Infer<typeof DISCOVERY>;
 
 /**
  * 相手の口の一覧。**一度読んだら覚えておきます。**
@@ -39,11 +42,7 @@ async function discover(fetcher: typeof fetch = fetch): Promise<Discovery> {
     const url = `${config.oidcIssuer}/.well-known/openid-configuration`;
     const res = await fetcher(url);
     if (!res.ok) throw new Error(`OIDC の設定を読めません (${res.status}) ${url}`);
-    const doc = (await res.json()) as Partial<Discovery>;
-    for (const key of ['issuer', 'authorization_endpoint', 'token_endpoint', 'jwks_uri'] as const) {
-        if (typeof doc[key] !== 'string') throw new Error(`OIDC の設定に ${key} がありません`);
-    }
-    discovered = doc as Discovery;
+    discovered = read(DISCOVERY, await res.json(), 'OIDC の設定');
     return discovered;
 }
 
@@ -202,20 +201,28 @@ async function publicKey(kid: string): Promise<CryptoKey> {
     return found;
 }
 
-export interface Claims {
-    sub: string;
-    name?: string;
-    preferred_username?: string;
-    email?: string;
-    groups?: string[];
+/**
+ * ID トークンの中身。**形はここで確かめる** (`shape.ts`)。相手が入れてくる
+ * 知らないクレームは捨てる (通すかどうかに使うのは下の分だけ)
+ */
+const CLAIMS = object({
+    sub: string,
+    name: optional(string),
+    preferred_username: optional(string),
+    email: optional(string),
+    groups: optional(array(string)),
     /** グループが多すぎて載せられなかったときに Entra が入れてくる印 */
-    _claim_names?: Record<string, string>;
-    iss: string;
-    aud: string | string[];
-    exp: number;
-    nbf?: number;
-    nonce?: string;
-}
+    _claim_names: optional(record(string)),
+    iss: string,
+    aud: either(string, array(string)),
+    exp: number,
+    nbf: optional(number),
+    nonce: optional(string),
+});
+export type Claims = Infer<typeof CLAIMS>;
+
+/** ヘッダのうち見るもの。署名方式と鍵の名前 */
+const HEADER = object({ alg: optional(string), kid: optional(string) });
 
 /** 時計のずれの許容 (秒)。RFC 7519 が「小さめに」と言っている程度 */
 const SKEW = 60;
@@ -240,10 +247,11 @@ export async function verify(token: string, nonce: string, at = Date.now()): Pro
         throw new Error('ID トークンの形が違います');
     }
 
-    const header = JSON.parse(new TextDecoder().decode(decodeBase64Url(rawHeader))) as {
-        alg?: string;
-        kid?: string;
-    };
+    const header = read(
+        HEADER,
+        JSON.parse(new TextDecoder().decode(decodeBase64Url(rawHeader))),
+        'ID トークンのヘッダ',
+    );
     // alg は相手が決めるものだが、こちらが受けるのは RS256 だけ。
     // none を受けると署名を見ない道ができてしまう
     if (header.alg !== 'RS256') throw new Error(`受けられない署名方式です (${header.alg})`);
@@ -257,7 +265,12 @@ export async function verify(token: string, nonce: string, at = Date.now()): Pro
     );
     if (!ok) throw new Error('ID トークンの署名が合いません');
 
-    const claims = JSON.parse(new TextDecoder().decode(decodeBase64Url(rawPayload))) as Claims;
+    // 署名を見てから開く。形の違いを言うのは、本物だと分かったものにだけ
+    const claims = read(
+        CLAIMS,
+        JSON.parse(new TextDecoder().decode(decodeBase64Url(rawPayload))),
+        'ID トークン',
+    );
     const doc = await discover();
     if (claims.iss !== doc.issuer) throw new Error('ID トークンの発行元が違います');
 
@@ -265,16 +278,13 @@ export async function verify(token: string, nonce: string, at = Date.now()): Pro
     if (!audience.includes(config.oidcClientId)) throw new Error('ID トークンの宛先が違います');
 
     const seconds = Math.floor(at / 1000);
-    if (typeof claims.exp !== 'number' || claims.exp + SKEW < seconds) {
-        throw new Error('ID トークンの期限が切れています');
-    }
-    if (typeof claims.nbf === 'number' && claims.nbf - SKEW > seconds) {
+    if (claims.exp + SKEW < seconds) throw new Error('ID トークンの期限が切れています');
+    if (claims.nbf !== undefined && claims.nbf - SKEW > seconds) {
         throw new Error('ID トークンがまだ有効ではありません');
     }
     // 出したときの合言葉と一致すること。これが「自分が始めたログイン」の証拠になる
     if (claims.nonce !== nonce) throw new Error('ID トークンの合言葉が合いません');
-    if (typeof claims.sub !== 'string' || claims.sub === '')
-        throw new Error('ID トークンに sub がありません');
+    if (claims.sub === '') throw new Error('ID トークンに sub がありません');
     return claims;
 }
 

--- a/src/lib/server/scramble.ts
+++ b/src/lib/server/scramble.ts
@@ -1,5 +1,6 @@
 import { closeSync, openSync, readSync } from 'node:fs';
 import { relative } from 'node:path';
+import { array, boolean, type Infer, object, optional, read, string } from '../shape';
 import { config } from './config';
 
 /**
@@ -69,12 +70,17 @@ export function isScrambled(path: string): boolean {
     return scrambledRatio(path) > THRESHOLD;
 }
 
-export interface CardStatus {
-    ok: boolean;
+/** エージェントの `/denpa/card` の答え。形はここで確かめる (`shape.ts`) */
+const CARD_STATUS = object({
+    ok: boolean,
     /** 画面にそのまま出す一言 */
-    message: string;
-    readers: string[];
-}
+    message: string,
+    readers: array(string),
+});
+export type CardStatus = Infer<typeof CARD_STATUS>;
+
+/** `/denpa/decode` の答え。断られたときは `error` に理由 */
+const DECODED = object({ ok: optional(boolean), error: optional(string) });
 
 /**
  * カードリーダーの状態。設定画面に出す。
@@ -91,12 +97,7 @@ export async function cardStatus(): Promise<CardStatus> {
         if (!res.ok) {
             return { ok: false, message: `解除の受け口が ${res.status} を返しました`, readers: [] };
         }
-        const body = (await res.json()) as Partial<CardStatus>;
-        return {
-            ok: body.ok === true,
-            message: body.message ?? '',
-            readers: body.readers ?? [],
-        };
+        return read(CARD_STATUS, await res.json(), 'エージェントの /denpa/card');
     } catch (error) {
         return { ok: false, message: `解除の受け口に繋がりません: ${error}`, readers: [] };
     }
@@ -138,7 +139,7 @@ export async function descramble(
             body: JSON.stringify({ input: from, output: to }),
             signal: signal ?? null,
         });
-        const body = (await res.json()) as { ok?: boolean; error?: string };
+        const body = read(DECODED, await res.json(), 'エージェントの /denpa/decode');
         if (!res.ok || body.ok !== true) {
             return { ok: false, error: body.error ?? `解除の受け口が ${res.status} を返しました` };
         }

--- a/src/lib/server/scramble.ts
+++ b/src/lib/server/scramble.ts
@@ -1,6 +1,6 @@
 import { closeSync, openSync, readSync } from 'node:fs';
 import { relative } from 'node:path';
-import { array, boolean, type Infer, object, optional, read, string } from '../shape';
+import { array, boolean, type Infer, object, optional, string, tolerate } from '../shape';
 import { config } from './config';
 
 /**
@@ -97,7 +97,7 @@ export async function cardStatus(): Promise<CardStatus> {
         if (!res.ok) {
             return { ok: false, message: `解除の受け口が ${res.status} を返しました`, readers: [] };
         }
-        return read(CARD_STATUS, await res.json(), 'エージェントの /denpa/card');
+        return tolerate(CARD_STATUS, await res.json(), 'エージェントの /denpa/card');
     } catch (error) {
         return { ok: false, message: `解除の受け口に繋がりません: ${error}`, readers: [] };
     }
@@ -139,7 +139,7 @@ export async function descramble(
             body: JSON.stringify({ input: from, output: to }),
             signal: signal ?? null,
         });
-        const body = read(DECODED, await res.json(), 'エージェントの /denpa/decode');
+        const body = tolerate(DECODED, await res.json(), 'エージェントの /denpa/decode');
         if (!res.ok || body.ok !== true) {
             return { ok: false, error: body.error ?? `解除の受け口が ${res.status} を返しました` };
         }

--- a/src/lib/server/tuner.ts
+++ b/src/lib/server/tuner.ts
@@ -8,39 +8,63 @@
  * `ts/service-filter.ts`、番組の切れ目を見るのは `ts/eit.ts`。
  */
 
+import {
+    array,
+    boolean,
+    type Infer,
+    literal,
+    nullable,
+    number,
+    object,
+    optional,
+    read,
+    type Shape,
+    string,
+} from '../shape';
 import type { ChannelType } from '../types';
 import { config } from './config';
 
-/** エージェントが知っているチャンネル。スキャンの結果そのもの */
-export interface AgentChannel {
-    type: ChannelType;
-    channel: string;
-    networkId: number;
-    transportStreamId: number;
-    remoteControlKeyId: number | null;
-    services: { serviceId: number; serviceType: number; name: string }[];
-}
+/*
+ * **エージェントが返すものの形は、ここで確かめてから型にする** (`shape.ts`)。
+ * 相手は別のリポジトリ (agent/) で、版がずれれば形もずれる。キャストで型を
+ * 付けていた頃は、ずれても「どこかで undefined」としてしか出なかった
+ */
+const CHANNEL_TYPE: Shape<ChannelType> = literal('GR', 'BS', 'CS', 'SKY');
 
-export interface AgentTuner {
-    index: number;
-    name: string;
-    types: ChannelType[];
-    disabled: boolean;
+/** エージェントが知っているチャンネル。スキャンの結果そのもの */
+const AGENT_CHANNEL = object({
+    type: CHANNEL_TYPE,
+    channel: string,
+    networkId: number,
+    transportStreamId: number,
+    remoteControlKeyId: nullable(number),
+    services: array(object({ serviceId: number, serviceType: number, name: string })),
+});
+export type AgentChannel = Infer<typeof AGENT_CHANNEL>;
+
+const AGENT_TUNER = object({
+    index: number,
+    name: string,
+    types: array(CHANNEL_TYPE),
+    disabled: boolean,
     /** 選局に使うデバイス。ここからエージェントがコマンドを組み立てる */
-    device: string | null;
+    device: nullable(string),
     /** 衛星の給電。要る構成だけ */
-    lnb: string | null;
+    lnb: nullable(string),
     /**
      * 選局コマンドの上書き。**設定ファイルに直に書いたときだけ入る。**
      * 画面からは渡せない (渡せると、あちらで好きなコマンドが走ってしまう)
      */
-    command: string | null;
+    command: nullable(string),
     /** いま掴んでいるチャンネル。空いていれば null */
-    channel: { type: ChannelType; channel: string } | null;
-    users: { use: string; priority: number }[];
-    pid: number | null;
-    error: string | null;
-}
+    channel: nullable(object({ type: CHANNEL_TYPE, channel: string })),
+    users: array(object({ use: string, priority: number })),
+    pid: nullable(number),
+    error: nullable(string),
+});
+export type AgentTuner = Infer<typeof AGENT_TUNER>;
+
+const TUNERS = object({ tuners: array(AGENT_TUNER), detected: optional(boolean) });
 
 /** 画面から書き換えられる部分だけ */
 export interface TunerConfig {
@@ -66,7 +90,7 @@ export function programKey(networkId: number, serviceId: number, eventId: number
     return serviceKey(networkId, serviceId) * 100000 + eventId;
 }
 
-async function get<T>(path: string, timeout = 10_000): Promise<T> {
+async function get<T>(path: string, shape: Shape<T>, timeout = 10_000): Promise<T> {
     const res = await fetch(`${config.agentUrl}${path}`, {
         headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(timeout),
@@ -74,11 +98,11 @@ async function get<T>(path: string, timeout = 10_000): Promise<T> {
     if (!res.ok) {
         throw new Error(`エージェント ${path} -> ${res.status} ${await res.text()}`);
     }
-    return (await res.json()) as T;
+    return read(shape, await res.json(), `エージェントの ${path}`);
 }
 
 export function getChannels(): Promise<AgentChannel[]> {
-    return get<AgentChannel[]>('/denpa/channels');
+    return get('/denpa/channels', array(AGENT_CHANNEL));
 }
 
 /**
@@ -99,16 +123,16 @@ export async function putChannels(found: AgentChannel[], scanned: ChannelType[])
         signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) throw new Error(`チャンネルを保存できません (${res.status}) ${await res.text()}`);
-    return (await res.json()) as AgentChannel[];
+    return read(array(AGENT_CHANNEL), await res.json(), 'エージェントの PUT /denpa/channels');
 }
 
 export async function getTuners(): Promise<AgentTuner[]> {
-    return (await get<{ tuners: AgentTuner[] }>('/denpa/tuners')).tuners;
+    return (await get('/denpa/tuners', TUNERS)).tuners;
 }
 
 /** 定義を書いていないので自分で見つけた状態か。画面に出す */
 export async function tunersDetected(): Promise<boolean> {
-    return (await get<{ detected?: boolean }>('/denpa/tuners')).detected === true;
+    return (await get('/denpa/tuners', TUNERS)).detected === true;
 }
 
 /**
@@ -128,8 +152,9 @@ export async function putTuners(tuners: TunerConfig[]): Promise<void> {
         signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? `チューナーを保存できません (${res.status})`);
+        const body = await res.json().catch(() => ({}));
+        const error = typeof body === 'object' && body !== null && 'error' in body ? body.error : undefined;
+        throw new Error(typeof error === 'string' ? error : `チューナーを保存できません (${res.status})`);
     }
 }
 

--- a/src/lib/server/tuner.ts
+++ b/src/lib/server/tuner.ts
@@ -17,9 +17,9 @@ import {
     number,
     object,
     optional,
-    read,
     type Shape,
     string,
+    tolerate,
 } from '../shape';
 import type { ChannelType } from '../types';
 import { config } from './config';
@@ -27,7 +27,10 @@ import { config } from './config';
 /*
  * **エージェントが返すものの形は、ここで確かめてから型にする** (`shape.ts`)。
  * 相手は別のリポジトリ (agent/) で、版がずれれば形もずれる。キャストで型を
- * 付けていた頃は、ずれても「どこかで undefined」としてしか出なかった
+ * 付けていた頃は、ずれても「どこかで undefined」としてしか出なかった。
+ *
+ * **違っていても止めない** (`tolerate`)。版がずれただけで録画が止まるのでは
+ * 困るので、警告を出して来たものをそのまま使う。直すのは人
  */
 const CHANNEL_TYPE: Shape<ChannelType> = literal('GR', 'BS', 'CS', 'SKY');
 
@@ -98,7 +101,7 @@ async function get<T>(path: string, shape: Shape<T>, timeout = 10_000): Promise<
     if (!res.ok) {
         throw new Error(`エージェント ${path} -> ${res.status} ${await res.text()}`);
     }
-    return read(shape, await res.json(), `エージェントの ${path}`);
+    return tolerate(shape, await res.json(), `エージェントの ${path}`);
 }
 
 export function getChannels(): Promise<AgentChannel[]> {
@@ -123,7 +126,7 @@ export async function putChannels(found: AgentChannel[], scanned: ChannelType[])
         signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) throw new Error(`チャンネルを保存できません (${res.status}) ${await res.text()}`);
-    return read(array(AGENT_CHANNEL), await res.json(), 'エージェントの PUT /denpa/channels');
+    return tolerate(array(AGENT_CHANNEL), await res.json(), 'エージェントの PUT /denpa/channels');
 }
 
 export async function getTuners(): Promise<AgentTuner[]> {

--- a/src/lib/shape.test.ts
+++ b/src/lib/shape.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    array,
+    boolean,
+    either,
+    type Infer,
+    literal,
+    nullable,
+    number,
+    object,
+    optional,
+    read,
+    record,
+    ShapeError,
+    string,
+} from './shape';
+
+const TUNER = object({
+    index: number,
+    name: string,
+    types: array(literal('GR', 'BS', 'CS')),
+    channel: nullable(object({ type: string, channel: string })),
+    error: optional(string),
+});
+type Tuner = Infer<typeof TUNER>;
+
+describe('外から来た JSON の形', () => {
+    test('合っていればそのまま型が付く', () => {
+        const tuner: Tuner = read(
+            TUNER,
+            { index: 0, name: 'PT3', types: ['GR'], channel: null, error: undefined },
+            'チューナー',
+        );
+        expect(tuner).toEqual({ index: 0, name: 'PT3', types: ['GR'], channel: null });
+        expect(tuner.channel?.type).toBeUndefined();
+    });
+
+    test('知らない鍵は捨て、無い optional は鍵ごと付けない', () => {
+        const tuner = read(
+            TUNER,
+            { index: 0, name: 'PT3', types: [], channel: null, extra: 1 },
+            'チューナー',
+        );
+        expect('extra' in tuner).toBe(false);
+        expect('error' in tuner).toBe(false);
+    });
+
+    test('違うところを道筋で言う', () => {
+        expect(() =>
+            read(TUNER, { index: 0, name: 'PT3', types: ['SKY'], channel: null }, 'チューナー'),
+        ).toThrow(
+            /チューナーの形が違います: types\[0\] は決まった値 \("GR" \/ "BS" \/ "CS"\)のはずが 文字列 "SKY"/,
+        );
+        expect(() => read(TUNER, { index: '0', name: 'PT3', types: [], channel: null }, 'x')).toThrow(
+            /index は数のはずが 文字列 "0"/,
+        );
+        expect(() => read(TUNER, { index: 0, name: 'PT3', types: [], channel: { type: 'GR' } }, 'x')).toThrow(
+            /channel\.channel は文字列のはずが 無し/,
+        );
+        expect(() => read(TUNER, null, 'x')).toThrow(ShapeError);
+        expect(() => read(TUNER, [], 'x')).toThrow(/全体 はオブジェクトのはずが 配列/);
+    });
+
+    test('nullable は無いのも null と読む', () => {
+        const tuner = read(TUNER, { index: 0, name: 'PT3', types: [] }, 'チューナー');
+        expect(tuner.channel).toBeNull();
+        expect(() => read(TUNER, { index: 0, name: 'PT3', types: [], channel: 1 }, 'x')).toThrow(
+            /channel はオブジェクトのはずが number 1/,
+        );
+    });
+
+    test('数は有限のものだけ', () => {
+        expect(() => read(number, Number.POSITIVE_INFINITY, 'x')).toThrow(ShapeError);
+        expect(() => read(number, Number.NaN, 'x')).toThrow(ShapeError);
+        expect(read(number, -1.5, 'x')).toBe(-1.5);
+    });
+
+    test('either は先に当たったほう', () => {
+        const aud = either(string, array(string));
+        expect(read(aud, 'a', 'x')).toBe('a');
+        expect(read(aud, ['a', 'b'], 'x')).toEqual(['a', 'b']);
+        // どちらでもなければ、最初の形の言い分で断る
+        expect(() => read(aud, 1, 'x')).toThrow(/文字列のはずが number 1/);
+    });
+
+    test('record は鍵を決めず、値の形だけ見る', () => {
+        expect(read(record(boolean), { a: true, b: false }, 'x')).toEqual({ a: true, b: false });
+        expect(() => read(record(boolean), { a: 1 }, 'x')).toThrow(/a は真偽のはずが number 1/);
+        expect(() => read(record(boolean), [], 'x')).toThrow(/オブジェクトのはずが 配列/);
+    });
+
+    test('ShapeError 以外はそのまま通す', () => {
+        const broken = () => {
+            throw new TypeError('別の失敗');
+        };
+        expect(() => read(broken, 1, 'x')).toThrow(TypeError);
+    });
+});

--- a/src/lib/shape.test.ts
+++ b/src/lib/shape.test.ts
@@ -62,6 +62,11 @@ describe('外から来た JSON の形', () => {
         expect(() => read(TUNER, [], 'x')).toThrow(/全体 はオブジェクトのはずが 配列/);
     });
 
+    test('optional は null も「無い」と読む (無いクレームを null で送る IdP がある)', () => {
+        const tuner = read(TUNER, { index: 0, name: 'PT3', types: [], error: null }, 'チューナー');
+        expect('error' in tuner).toBe(false);
+    });
+
     test('nullable は無いのも null と読む', () => {
         const tuner = read(TUNER, { index: 0, name: 'PT3', types: [] }, 'チューナー');
         expect(tuner.channel).toBeNull();
@@ -104,6 +109,9 @@ describe('外から来た JSON の形', () => {
             /^\[shape\] エージェントの \/denpa\/tunersの形が違います \(相手の版がずれている\?\)。そのまま使います: /,
         );
         expect(warnings[0]).toContain('types[0] は決まった値');
+        // 同じ口なら、違いの中身 (値) が変わっても繰り返さない
+        tolerate(TUNER, { index: 0, name: 'PT3', types: ['CATV'] }, 'エージェントの /denpa/tuners', warn);
+        expect(warnings).toHaveLength(1);
         // 合っていれば黙って読む
         expect(tolerate(TUNER, { index: 1, name: 'x', types: [] }, 'y', warn).channel).toBeNull();
         expect(warnings).toHaveLength(1);

--- a/src/lib/shape.test.ts
+++ b/src/lib/shape.test.ts
@@ -13,6 +13,7 @@ import {
     record,
     ShapeError,
     string,
+    tolerate,
 } from './shape';
 
 const TUNER = object({
@@ -87,6 +88,25 @@ describe('外から来た JSON の形', () => {
         expect(read(record(boolean), { a: true, b: false }, 'x')).toEqual({ a: true, b: false });
         expect(() => read(record(boolean), { a: 1 }, 'x')).toThrow(/a は真偽のはずが number 1/);
         expect(() => read(record(boolean), [], 'x')).toThrow(/オブジェクトのはずが 配列/);
+    });
+
+    test('tolerate は形が違っても止めず、1回だけ警告して通す', () => {
+        const warnings: string[] = [];
+        const warn = (message: string) => warnings.push(message);
+        const odd: unknown = { index: 0, name: 'PT3', types: ['SAT'], channel: null };
+        // 型は付くが中身はそのまま (版がずれた相手を止めない)
+        const first: unknown = tolerate(TUNER, odd, 'エージェントの /denpa/tuners', warn);
+        const second: unknown = tolerate(TUNER, odd, 'エージェントの /denpa/tuners', warn);
+        expect(first).toBe(odd);
+        expect(second).toBe(odd);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toMatch(
+            /^\[shape\] エージェントの \/denpa\/tunersの形が違います \(相手の版がずれている\?\)。そのまま使います: /,
+        );
+        expect(warnings[0]).toContain('types[0] は決まった値');
+        // 合っていれば黙って読む
+        expect(tolerate(TUNER, { index: 1, name: 'x', types: [] }, 'y', warn).channel).toBeNull();
+        expect(warnings).toHaveLength(1);
     });
 
     test('ShapeError 以外はそのまま通す', () => {

--- a/src/lib/shape.ts
+++ b/src/lib/shape.ts
@@ -123,7 +123,8 @@ export function object<F extends Fields>(fields: F): Shape<ObjectOf<F>> {
         const out: Record<string, unknown> = {};
         for (const [key, shape] of Object.entries(fields)) {
             const parsed = shape(source[key], path === '' ? key : `${path}.${key}`);
-            if (parsed !== undefined || key in source) out[key] = parsed;
+            // 無い (undefined / null を optional が「無い」と読んだ) 鍵は付けない
+            if (parsed !== undefined) out[key] = parsed;
         }
         return out as ObjectOf<F>;
     };

--- a/src/lib/shape.ts
+++ b/src/lib/shape.ts
@@ -125,12 +125,43 @@ export function object<F extends Fields>(fields: F): Shape<ObjectOf<F>> {
     };
 }
 
-/** 読む。失敗の言葉に、何を読んでいたかを添える (`エージェントの /denpa/tuners の形が違います: …`) */
+/**
+ * 読む。**形が違えば止める。** 失敗の言葉に、何を読んでいたかを添える
+ * (`ID トークンの形が違います: exp は数のはずが 無し`)。
+ *
+ * 止めてよいのは、違う形のまま進むと危ないところ (ID トークン) だけ。相手が
+ * 別の版で動いているだけなら止めずに通す (`tolerate`)
+ */
 export function read<T>(shape: Shape<T>, value: unknown, what: string): T {
     try {
         return shape(value, '');
     } catch (error) {
         if (error instanceof ShapeError) throw new ShapeError(`${what}の形が違います: ${error.message}`);
         throw error;
+    }
+}
+
+/** 同じ警告を繰り返さない (チューナーの状態は何秒かおきに読む) */
+const warned = new Set<string>();
+
+/**
+ * 読む。**形が違っても止めない。** 警告を1回だけ出して、来たものをそのまま型にする
+ * (前の `as X` と同じ振る舞い)。
+ *
+ * 相手 (チューナーエージェント) は別のリポジトリで、版がずれると鍵が増えたり
+ * 名前が変わったりする。そのたびに録画が止まるのでは困る — 動いているものは
+ * 動かしたまま、**どこが違うかを言う**。直すのは人
+ */
+export function tolerate<T>(shape: Shape<T>, value: unknown, what: string, warn = console.warn): T {
+    try {
+        return shape(value, '');
+    } catch (error) {
+        if (!(error instanceof ShapeError)) throw error;
+        const message = `[shape] ${what}の形が違います (相手の版がずれている?)。そのまま使います: ${error.message}`;
+        if (!warned.has(message)) {
+            warned.add(message);
+            warn(message);
+        }
+        return value as T;
     }
 }

--- a/src/lib/shape.ts
+++ b/src/lib/shape.ts
@@ -1,0 +1,136 @@
+/**
+ * 外から来た JSON の形を確かめて、型を付ける。
+ *
+ * `res.json() as X` はキャストで、相手が本当にその形を返しているかは見ていない。
+ * 相手が別のもの (チューナーエージェント、OIDC の相手、取り込み元の DB) なら、
+ * 境界で1回だけ形を確かめて、以降は型のとおりに触る — DB の列を `schema.ts` の
+ * 読み手で読むのと同じ理屈。ライブラリは入れていない。要るのは下の 10 個で足りる。
+ *
+ * 形は `object({ ... })` のように書き、型はそこから導く (`Infer<typeof SHAPE>`)。
+ * 型と読み手を別々に書くと、片方だけ直したときに TS は何も言わない。
+ *
+ * 読めなければ `ShapeError` を投げる。どこが違うかを道筋 (`tuners[0].name`) で言う —
+ * 「形が違う」だけでは、相手のどの版と噛み合っていないのか分からない
+ */
+
+export class ShapeError extends Error {}
+
+/** 読み手。`path` は失敗したときに言う道筋 */
+export type Shape<T> = (value: unknown, path: string) => T;
+
+export type Infer<S> = S extends Shape<infer T> ? T : never;
+
+function describe(value: unknown): string {
+    if (value === null) return 'null';
+    if (value === undefined) return '無し';
+    if (Array.isArray(value)) return '配列';
+    if (typeof value === 'string') return `文字列 ${JSON.stringify(value.slice(0, 40))}`;
+    if (typeof value === 'object') return 'オブジェクト';
+    return `${typeof value} ${String(value)}`;
+}
+
+function refuse(path: string, expected: string, value: unknown): never {
+    throw new ShapeError(`${path === '' ? '全体' : path} は${expected}のはずが ${describe(value)}`);
+}
+
+export const string: Shape<string> = (value, path) =>
+    typeof value === 'string' ? value : refuse(path, '文字列', value);
+
+/** 有限の数。JSON に NaN は無いが、`Infinity` を投げてくる実装はある */
+export const number: Shape<number> = (value, path) =>
+    typeof value === 'number' && Number.isFinite(value) ? value : refuse(path, '数', value);
+
+export const boolean: Shape<boolean> = (value, path) =>
+    typeof value === 'boolean' ? value : refuse(path, '真偽', value);
+
+/** 何でもよい。形を見ないところ (相手に丸ごと渡すもの) にだけ使う */
+export const unknown: Shape<unknown> = (value) => value;
+
+/** 決まった値のどれか。`literal('GR', 'BS')` で `'GR' | 'BS'` */
+export function literal<const L extends string | number | boolean>(...options: L[]): Shape<L> {
+    return (value, path) =>
+        options.some((option) => option === value)
+            ? (value as L)
+            : refuse(path, `決まった値 (${options.map((o) => JSON.stringify(o)).join(' / ')})`, value);
+}
+
+/** 無くてもよい。`object` の中では、無ければ鍵ごと付けない */
+export function optional<T>(shape: Shape<T>): Shape<T | undefined> {
+    return (value, path) => (value === undefined ? undefined : shape(value, path));
+}
+
+/** null でもよい。**無いのも null と読む** — null の鍵を省いて書く実装がある (手で書いた設定ファイルも) */
+export function nullable<T>(shape: Shape<T>): Shape<T | null> {
+    return (value, path) => (value === null || value === undefined ? null : shape(value, path));
+}
+
+export function array<T>(item: Shape<T>): Shape<T[]> {
+    return (value, path) =>
+        Array.isArray(value)
+            ? value.map((entry, i) => item(entry, `${path}[${i}]`))
+            : refuse(path, '配列', value);
+}
+
+/** 鍵が決まっていないオブジェクト。値の形だけ見る */
+export function record<T>(item: Shape<T>): Shape<Record<string, T>> {
+    return (value, path) => {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+            return refuse(path, 'オブジェクト', value);
+        }
+        const out: Record<string, T> = {};
+        for (const [key, entry] of Object.entries(value))
+            out[key] = item(entry, path === '' ? key : `${path}.${key}`);
+        return out;
+    };
+}
+
+/** どちらか。先に当たったほうの形になる */
+export function either<A, B>(a: Shape<A>, b: Shape<B>): Shape<A | B> {
+    return (value, path) => {
+        try {
+            return a(value, path);
+        } catch (first) {
+            try {
+                return b(value, path);
+            } catch {
+                throw first;
+            }
+        }
+    };
+}
+
+type Fields = Record<string, Shape<unknown>>;
+type OptionalKeys<F extends Fields> = { [K in keyof F]: undefined extends Infer<F[K]> ? K : never }[keyof F];
+/** `optional()` の鍵は省ける形にする (exactOptionalPropertyTypes に合わせて、無ければ鍵ごと無い) */
+type ObjectOf<F extends Fields> = { [K in Exclude<keyof F, OptionalKeys<F>>]: Infer<F[K]> } & {
+    [K in OptionalKeys<F>]?: Infer<F[K]>;
+};
+
+/**
+ * 決まった鍵を持つオブジェクト。**知らない鍵は捨てる** — 相手が足したものを
+ * こちらの型に混ぜないため。丸ごと要るなら `record(unknown)` で受ける
+ */
+export function object<F extends Fields>(fields: F): Shape<ObjectOf<F>> {
+    return (value, path) => {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+            return refuse(path, 'オブジェクト', value);
+        }
+        const source = value as Record<string, unknown>;
+        const out: Record<string, unknown> = {};
+        for (const [key, shape] of Object.entries(fields)) {
+            const parsed = shape(source[key], path === '' ? key : `${path}.${key}`);
+            if (parsed !== undefined || key in source) out[key] = parsed;
+        }
+        return out as ObjectOf<F>;
+    };
+}
+
+/** 読む。失敗の言葉に、何を読んでいたかを添える (`エージェントの /denpa/tuners の形が違います: …`) */
+export function read<T>(shape: Shape<T>, value: unknown, what: string): T {
+    try {
+        return shape(value, '');
+    } catch (error) {
+        if (error instanceof ShapeError) throw new ShapeError(`${what}の形が違います: ${error.message}`);
+        throw error;
+    }
+}

--- a/src/lib/shape.ts
+++ b/src/lib/shape.ts
@@ -54,9 +54,13 @@ export function literal<const L extends string | number | boolean>(...options: L
             : refuse(path, `決まった値 (${options.map((o) => JSON.stringify(o)).join(' / ')})`, value);
 }
 
-/** 無くてもよい。`object` の中では、無ければ鍵ごと付けない */
+/**
+ * 無くてもよい。`object` の中では、無ければ鍵ごと付けない。
+ * **null も「無い」と読む** — 無いクレームを null で送る IdP がある。ログインが
+ * そこで止まるのは、こちらの型の都合を相手に押し付けている
+ */
 export function optional<T>(shape: Shape<T>): Shape<T | undefined> {
-    return (value, path) => (value === undefined ? undefined : shape(value, path));
+    return (value, path) => (value === undefined || value === null ? undefined : shape(value, path));
 }
 
 /** null でもよい。**無いのも null と読む** — null の鍵を省いて書く実装がある (手で書いた設定ファイルも) */
@@ -141,7 +145,11 @@ export function read<T>(shape: Shape<T>, value: unknown, what: string): T {
     }
 }
 
-/** 同じ警告を繰り返さない (チューナーの状態は何秒かおきに読む) */
+/**
+ * 警告を出した口 (`what`)。同じ口では繰り返さない — チューナーの状態は何秒か
+ * おきに読むし、言葉には値が入るので (掴んでいるチャンネルなど)、言葉ごとに
+ * 覚えると増え続ける。最初の 1 回で直すべき場所は分かる
+ */
 const warned = new Set<string>();
 
 /**
@@ -157,10 +165,9 @@ export function tolerate<T>(shape: Shape<T>, value: unknown, what: string, warn 
         return shape(value, '');
     } catch (error) {
         if (!(error instanceof ShapeError)) throw error;
-        const message = `[shape] ${what}の形が違います (相手の版がずれている?)。そのまま使います: ${error.message}`;
-        if (!warned.has(message)) {
-            warned.add(message);
-            warn(message);
+        if (!warned.has(what)) {
+            warned.add(what);
+            warn(`[shape] ${what}の形が違います (相手の版がずれている?)。そのまま使います: ${error.message}`);
         }
         return value as T;
     }


### PR DESCRIPTION
## 何を

外から来る JSON を `res.json() as X` で型にしていたところを、形を確かめてから型にするようにしました (#47 の続きで挙げた「外から来る JSON の読み手」)。

### 読み手 (`src/lib/shape.ts`)

`string / number / boolean / literal / optional / nullable / array / record / either / object` と、読む口が `tolerate` と `read` の 2 つ。**ライブラリは入れていません** — 境界は 3 つ (エージェント・OIDC・取り込み元 DB) しか無く、要るのはこれで足ります。形は `object({ ... })` で書き、型はそこから導きます (`Infer<typeof AGENT_CHANNEL>`)。DB の列を `schema.ts` の読み手で読むのと同じ理屈で、形と型を別々に書きません。

**形が違っても止めない (`tolerate`)。** 相手 (エージェント) が別の版で動いているだけのことがあり、そのたびに録画が止まるのでは困ります。警告を 1 回だけ出して (何秒かおきに読むチューナーの状態で繰り返さない)、来たものをそのまま型にします — 前の `as X` と同じ振る舞いに、**どこが違うか**が付きます:

```
[shape] エージェントの /denpa/tunersの形が違います (相手の版がずれている?)。そのまま使います: tuners[0].types[1] は決まった値 ("GR" / "BS" / "CS" / "SKY") のはずが 文字列 "SAT"
```

止める (`read`) のは、違う形のまま進むと危ない ID トークンだけです (元から署名・期限・宛先・sub を厳密に見ていて、そこに形の確認が乗っただけ)。

`object` は知らない鍵を捨て (相手が足したものをこちらの型に混ぜない)、`optional` の鍵は無ければ鍵ごと付けません (`exactOptionalPropertyTypes` に合わせて)。`nullable` は無いのも null と読みます (null の鍵を省く実装や、手で書いた設定ファイルのため)。

### 当てたところ

- **チューナーエージェント** (`tuner.ts`, `tolerate`): `/denpa/channels` の GET / PUT、`/denpa/tuners`。`AgentChannel` / `AgentTuner` の interface は形から導く型に替えました。.NET 側の `TunerPool.Status()` が全部の鍵を (null 込みで) 出していることは確かめてあります
- **カードと解除** (`scramble.ts`, `tolerate`): `/denpa/card`、`/denpa/decode`
- **OIDC** (`oidc.ts`, `read`): discovery (4 つの鍵を手で見ていたのを形に)、ID トークンのヘッダとクレーム。`Claims` も形から。署名を確かめてから開くのは前のままです
- **取り込み** (`migrate.ts`): EPGStation の `channelIds` (読めなければ前と同じく空)

**触っていないもの**: 自分のサーバから自分の画面へ渡す JSON (WebSocket の `Notice`、`/api/...` の答え、Service Worker の postMessage)。同じリポジトリの中なので型は共有していて、実行時に確かめる価値が薄い割に画面側の量が増えます。`docs/development.md` にそう書きました。

## 確かめたこと

- `biome check .` / `svelte-check` 0 エラー
- 単体 801 本 (`shape.test.ts` 9 本を追加)
- e2e 全体

🤖 Generated with [Claude Code](https://claude.com/claude-code)
