### PR TITLE
refactor: 試験の生 SQL と、最後に残っていた UPDATE … FROM を orm() にする

### DIFF
--- a/src/lib/server/encoder-pump.test.ts
+++ b/src/lib/server/encoder-pump.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
 
 /**
  * エンコードキューの毒ジョブ対策。
@@ -21,35 +22,43 @@ const { config } = await import('./config');
 config.dbPath = join(mkdtempSync(join(tmpdir(), 'denpa-encpump-')), 'denpa.db');
 config.encodeMaxAttempts = 5;
 
-const { database } = await import('./db');
+const { orm } = await import('./db');
+const { encodeJobs, recordings } = await import('./schema');
 const { pump } = await import('./encoder');
 
 const now = Date.now();
 
 function reset(): void {
-    const db = database();
-    db.exec('DELETE FROM recordings; DELETE FROM encode_jobs');
-    db.prepare(
-        `INSERT INTO recordings (id, service_id, name, start_at, end_at, created_at, updated_at)
-         VALUES (1, 1, '毒番組', ?, ?, ?, ?)`,
-    ).run(now, now, now, now);
+    orm().delete(recordings).run();
+    orm().delete(encodeJobs).run();
+    orm()
+        .insert(recordings)
+        .values({
+            id: 1,
+            service_id: 1,
+            name: '毒番組',
+            start_at: now,
+            end_at: now,
+            created_at: now,
+            updated_at: now,
+        })
+        .run();
 }
 
 function seedJob(attempts: number): number {
-    return Number(
-        database()
-            .prepare(
-                `INSERT INTO encode_jobs (recording_id, state, attempts, created_at) VALUES (1, 'queued', ?, ?)`,
-            )
-            .run(attempts, now).lastInsertRowid,
-    );
+    return orm()
+        .insert(encodeJobs)
+        .values({ recording_id: 1, state: 'queued', attempts, created_at: now })
+        .returning({ id: encodeJobs.id })
+        .get()!.id;
 }
 
 function job(jobId: number): { state: string; attempts: number } {
-    return database().prepare('SELECT state, attempts FROM encode_jobs WHERE id = ?').get(jobId) as {
-        state: string;
-        attempts: number;
-    };
+    return orm()
+        .select({ state: encodeJobs.state, attempts: encodeJobs.attempts })
+        .from(encodeJobs)
+        .where(eq(encodeJobs.id, jobId))
+        .get()!;
 }
 
 test('上限を超えたジョブは掴まずに failed へ倒す', () => {

--- a/src/lib/server/epg.test.ts
+++ b/src/lib/server/epg.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { count, eq, sql } from 'drizzle-orm';
 
 /**
  * 局だけの取り込み。
@@ -47,26 +48,32 @@ const server = Bun.serve({
 });
 config.agentUrl = `http://127.0.0.1:${server.port}`;
 
-const { database } = await import('./db');
-const { airing, savePrograms, SERVICE_ORDER, SERVICE_TYPE_ORDER, syncServicesOnly } = await import('./epg');
+const { orm } = await import('./db');
+const { programs, reservations, services } = await import('./schema');
+const { airing, savePrograms, SERVICE_ORDER, SERVICE_TYPE_ORDER, settle, syncServicesOnly } = await import(
+    './epg'
+);
 
 describe('syncServicesOnly', () => {
     test('番組表を待たずに局だけ取り込む', async () => {
         expect(await syncServicesOnly()).toBe(1);
 
-        const rows = database().query('SELECT id, name, type FROM services').all();
+        const rows = orm()
+            .select({ id: services.id, name: services.name, type: services.type })
+            .from(services)
+            .all();
         // 全角英数は取り込むときに直す。他の画面と字面がずれると別の局に見える
         // 内部IDは networkId * 100000 + serviceId。録画が参照しているので変えられない
         expect(rows).toEqual([{ id: 3239123608, name: 'TOKYO MX', type: 'GR' }]);
 
         // 選局していないこと。局の一覧はスキャンの結果を読むだけで手に入る
         expect(asked).toEqual(['/denpa/channels']);
-        expect(database().query('SELECT COUNT(*) AS n FROM programs').get()).toEqual({ n: 0 });
+        expect(orm().select({ n: count() }).from(programs).get()).toEqual({ n: 0 });
     });
 
     test('何度呼んでも増えない', async () => {
         await syncServicesOnly();
-        expect(database().query('SELECT COUNT(*) AS n FROM services').get()).toEqual({ n: 1 });
+        expect(orm().select({ n: count() }).from(services).get()).toEqual({ n: 1 });
     });
 });
 
@@ -77,31 +84,45 @@ describe('syncServicesOnly', () => {
  * もう選局できない局の番組が数万件残り、検索にも引っかかり続けていた。
  */
 describe('消えた局の片付け', () => {
-    const db = () => database();
-
     function seed(serviceId: number): void {
-        db().exec('DELETE FROM programs; DELETE FROM reservations');
-        db()
-            .prepare(
-                `INSERT INTO programs (id, service_id, network_id, event_id, start_at, end_at, name,
-                                   description, is_free, updated_at)
-             VALUES (1, ?, 32391, 1, ?, ?, '消える局の番組', '', 1, ?)`,
-            )
-            .run(serviceId, Date.now(), Date.now() + 1800_000, Date.now());
-        db()
-            .prepare(
-                `INSERT INTO reservations (id, program_id, service_id, name, description, start_at, end_at,
-                                       state, created_at, updated_at)
-             VALUES (1, 1, ?, '消える局の予約', '', ?, ?, 'scheduled', ?, ?)`,
-            )
-            .run(serviceId, Date.now(), Date.now() + 1800_000, Date.now(), Date.now());
+        orm().delete(programs).run();
+        orm().delete(reservations).run();
+        const at = Date.now();
+        orm()
+            .insert(programs)
+            .values({
+                id: 1,
+                service_id: serviceId,
+                network_id: 32391,
+                event_id: 1,
+                start_at: at,
+                end_at: at + 1800_000,
+                name: '消える局の番組',
+                updated_at: at,
+            })
+            .run();
+        orm()
+            .insert(reservations)
+            .values({
+                id: 1,
+                program_id: 1,
+                service_id: serviceId,
+                name: '消える局の予約',
+                start_at: at,
+                end_at: at + 1800_000,
+                created_at: at,
+                updated_at: at,
+            })
+            .run();
     }
 
     /** その局を「しばらく見かけていない」ことにする。時計を進める代わり */
     function unseenFor(serviceId: number, ms: number): void {
-        db()
-            .prepare('UPDATE services SET updated_at = ? WHERE id = ?')
-            .run(Date.now() - ms, serviceId);
+        orm()
+            .update(services)
+            .set({ updated_at: Date.now() - ms })
+            .where(eq(services.id, serviceId))
+            .run();
     }
 
     test('番組表は消し、まだ始めていない予約は取り消す。局の行は残す', async () => {
@@ -114,15 +135,21 @@ describe('消えた局の片付け', () => {
         unseenFor(3239123608, config.serviceForgetAfter + 1);
         await syncServicesOnly();
 
-        expect(db().query('SELECT COUNT(*) AS n FROM programs').get()).toEqual({ n: 0 });
-        expect(db().query('SELECT state FROM reservations WHERE id = 1').get()).toEqual({
+        expect(orm().select({ n: count() }).from(programs).get()).toEqual({ n: 0 });
+        expect(
+            orm()
+                .select({ state: reservations.state })
+                .from(reservations)
+                .where(eq(reservations.id, 1))
+                .get(),
+        ).toEqual({
             state: 'canceled',
         });
         /*
          * 局の行そのものは残す。消すと、その局で録った録画や過去の予約が
          * 辿れなくなる。画面に出さない仕組みは別にある (CURRENT_SERVICES)
          */
-        expect(db().query('SELECT COUNT(*) AS n FROM services').get()).toEqual({ n: 2 });
+        expect(orm().select({ n: count() }).from(services).get()).toEqual({ n: 2 });
     });
 
     test('1局も返ってこなかった回では何もしない', async () => {
@@ -137,8 +164,14 @@ describe('消えた局の片付け', () => {
         offered = [];
         await syncServicesOnly();
 
-        expect(db().query('SELECT COUNT(*) AS n FROM programs').get()).toEqual({ n: 1 });
-        expect(db().query('SELECT state FROM reservations WHERE id = 1').get()).toEqual({
+        expect(orm().select({ n: count() }).from(programs).get()).toEqual({ n: 1 });
+        expect(
+            orm()
+                .select({ state: reservations.state })
+                .from(reservations)
+                .where(eq(reservations.id, 1))
+                .get(),
+        ).toEqual({
             state: 'scheduled',
         });
     });
@@ -158,8 +191,14 @@ describe('消えた局の片付け', () => {
         offered = [channel(23609, '別の局')];
         await syncServicesOnly();
 
-        expect(db().query('SELECT COUNT(*) AS n FROM programs').get()).toEqual({ n: 1 });
-        expect(db().query('SELECT state FROM reservations WHERE id = 1').get()).toEqual({
+        expect(orm().select({ n: count() }).from(programs).get()).toEqual({ n: 1 });
+        expect(
+            orm()
+                .select({ state: reservations.state })
+                .from(reservations)
+                .where(eq(reservations.id, 1))
+                .get(),
+        ).toEqual({
             state: 'scheduled',
         });
     });
@@ -173,8 +212,6 @@ describe('消えた局の片付け', () => {
  * 片方しか読めなかった回に、もう片方を消させない。
  */
 describe('savePrograms', () => {
-    const db = () => database();
-
     function event(overrides: Record<string, unknown> = {}) {
         return {
             serviceId: 23608,
@@ -198,49 +235,117 @@ describe('savePrograms', () => {
     test('題名の無い回で、入っている題名を消さない', async () => {
         offered = [channel(23608, 'ＴＯＫＹＯ　ＭＸ')];
         await syncServicesOnly();
-        db().exec('DELETE FROM programs');
+        orm().delete(programs).run();
 
         savePrograms([event()]);
         // 詳細だけ読めた回。題名も説明も空で来る
         savePrograms([event({ name: '', description: '', extended: { 番組内容: 'あらすじ' } })]);
 
-        expect(db().query('SELECT name, description, extended FROM programs').all()).toEqual([
-            {
-                name: 'テスト番組',
-                description: 'これは説明です',
-                extended: JSON.stringify({ 番組内容: 'あらすじ' }),
-            },
+        expect(
+            orm()
+                .select({
+                    name: programs.name,
+                    description: programs.description,
+                    extended: programs.extended,
+                })
+                .from(programs)
+                .all(),
+        ).toEqual([
+            { name: 'テスト番組', description: 'これは説明です', extended: { 番組内容: 'あらすじ' } },
         ]);
+    });
+
+    /*
+     * **予約の追従。** 番組表が書き換わったぶんを、まだ始めていない予約に写す。
+     * 時刻だけでなく名前も (「[新]」が付く、サブタイトルが入る)。録り始めた予約は動かさない
+     */
+    test('番組表が動いたら、まだ始めていない予約だけ追従する', async () => {
+        offered = [channel(23608, 'ＴＯＫＹＯ　ＭＸ')];
+        await syncServicesOnly();
+        orm().delete(programs).run();
+        orm().delete(reservations).run();
+
+        const base = Date.now() + 3 * 3600_000;
+        savePrograms([
+            event({ eventId: 1, startAt: base, duration: 1800_000 }),
+            event({ eventId: 2, name: '録画中の番組', startAt: base + 3600_000, duration: 1800_000 }),
+        ]);
+        const [waiting, started] = orm()
+            .select({ id: programs.id })
+            .from(programs)
+            .orderBy(programs.event_id)
+            .all();
+        if (waiting === undefined || started === undefined) throw new Error('番組が入っていない');
+        // 予約は古い時刻と名前のまま
+        // 手で入れた予約 (ルールに紐付かないものは、当て直しで引っ込められないように manual)
+        const stale = {
+            service_id: 3239123608,
+            name: '古い名前',
+            manual: true,
+            created_at: base,
+            updated_at: base,
+        };
+        orm()
+            .insert(reservations)
+            .values([
+                { id: 1, program_id: waiting.id, start_at: base - 60_000, end_at: base + 1800_000, ...stale },
+                // 録り始めている
+                {
+                    id: 2,
+                    program_id: started.id,
+                    start_at: base + 3600_000 - 60_000,
+                    end_at: base + 5400_000,
+                    started_at: base,
+                    ...stale,
+                },
+            ])
+            .run();
+
+        expect(settle().retimed).toBe(1);
+        expect(
+            orm()
+                .select({ id: reservations.id, name: reservations.name, start_at: reservations.start_at })
+                .from(reservations)
+                .orderBy(reservations.id)
+                .all(),
+        ).toEqual([
+            { id: 1, name: 'テスト番組', start_at: base },
+            { id: 2, name: '古い名前', start_at: base + 3600_000 - 60_000 },
+        ]);
+        // 二度目は何も動かない
+        expect(settle().retimed).toBe(0);
     });
 
     test('題名だけ読めた回で、入っている番組内容を消さない', async () => {
         offered = [channel(23608, 'ＴＯＫＹＯ　ＭＸ')];
         await syncServicesOnly();
-        db().exec('DELETE FROM programs');
+        orm().delete(programs).run();
 
         savePrograms([event({ name: '', description: '', extended: { 番組内容: 'あらすじ' } })]);
         savePrograms([event()]);
 
-        expect(db().query('SELECT name, extended FROM programs').all()).toEqual([
-            { name: 'テスト番組', extended: JSON.stringify({ 番組内容: 'あらすじ' }) },
-        ]);
+        expect(
+            orm().select({ name: programs.name, extended: programs.extended }).from(programs).all(),
+        ).toEqual([{ name: 'テスト番組', extended: { 番組内容: 'あらすじ' } }]);
     });
 
     test('題名の書き換えはこれまでどおり通る', async () => {
         offered = [channel(23608, 'ＴＯＫＹＯ　ＭＸ')];
         await syncServicesOnly();
-        db().exec('DELETE FROM programs');
+        orm().delete(programs).run();
 
         savePrograms([event()]);
         savePrograms([event({ name: '[新]テスト番組' })]);
 
-        expect(db().query('SELECT name FROM programs').all()).toEqual([{ name: '[新]テスト番組' }]);
+        expect(orm().select({ name: programs.name }).from(programs).all()).toEqual([
+            { name: '[新]テスト番組' },
+        ]);
     });
 
     test('延長で重なった番組は消える (あとから来たほうが勝つ)', async () => {
         offered = [channel(23608, 'ＴＯＫＹＯ　ＭＸ')];
         await syncServicesOnly();
-        db().exec('DELETE FROM programs');
+        orm().delete(programs).run();
 
         const base = Date.now();
         // 野球 10:15〜11:05 と、その後の2本
@@ -253,13 +358,15 @@ describe('savePrograms', () => {
         // 野球が 11:54 まで延長 (EIT[p/f])。潰された2本は局の送り直しまで書き換わらない
         savePrograms([event({ eventId: 1, name: '野球', startAt: base, duration: 99 * 60_000 })]);
 
-        expect(db().query('SELECT name FROM programs ORDER BY start_at').all()).toEqual([{ name: '野球' }]);
+        expect(orm().select({ name: programs.name }).from(programs).orderBy(programs.start_at).all()).toEqual(
+            [{ name: '野球' }],
+        );
     });
 
     test('隣り合っているだけ (境界が同じ) の番組は消えない', async () => {
         offered = [channel(23608, 'ＴＯＫＹＯ　ＭＸ')];
         await syncServicesOnly();
-        db().exec('DELETE FROM programs');
+        orm().delete(programs).run();
 
         const base = Date.now();
         savePrograms([
@@ -269,10 +376,9 @@ describe('savePrograms', () => {
         // 同じものをもう一度読んでも (カルーセルは回り続ける) 隣は消えない
         savePrograms([event({ eventId: 1, name: '前の番組', startAt: base, duration: 30 * 60_000 })]);
 
-        expect(db().query('SELECT name FROM programs ORDER BY start_at').all()).toEqual([
-            { name: '前の番組' },
-            { name: '次の番組' },
-        ]);
+        expect(orm().select({ name: programs.name }).from(programs).orderBy(programs.start_at).all()).toEqual(
+            [{ name: '前の番組' }, { name: '次の番組' }],
+        );
     });
 });
 
@@ -325,27 +431,37 @@ describe('SERVICE_ORDER', () => {
     function put(
         id: number,
         serviceId: number,
-        type: string,
+        type: 'GR' | 'BS' | 'CS',
         channel: string,
         key: number | null,
         name: string,
     ) {
-        database()
-            .query(
-                `INSERT INTO services (id, service_id, network_id, name, type, service_type,
-                                       channel, remote_control_key, has_logo, updated_at)
-                 VALUES (?, ?, 4, ?, ?, 1, ?, ?, 0, 1)`,
-            )
-            .run(id, serviceId, name, type, channel, key);
+        orm()
+            .insert(services)
+            .values({
+                id,
+                service_id: serviceId,
+                network_id: 4,
+                name,
+                type,
+                service_type: 1,
+                channel,
+                remote_control_key: key,
+                updated_at: 1,
+            })
+            .run();
     }
 
-    const ordered = (sql: string) =>
-        (database().query(`SELECT name FROM services ORDER BY ${sql}`).all() as { name: string }[]).map(
-            (row) => row.name,
-        );
+    const ordered = (order: string) =>
+        orm()
+            .select({ name: services.name })
+            .from(services)
+            .orderBy(sql.raw(order))
+            .all()
+            .map((row) => row.name);
 
     test('BS は物理チャンネルではなく3桁番号の順に並ぶ', () => {
-        database().query('DELETE FROM services').run();
+        orm().delete(services).run();
         // 実機の並び。BS-TBS (161) は BS朝日 (151) より前の中継に乗っている
         put(400161, 161, 'BS', 'BS01_1', null, 'BS-TBS');
         put(400151, 151, 'BS', 'BS01_3', null, 'BS朝日1');
@@ -357,7 +473,7 @@ describe('SERVICE_ORDER', () => {
     });
 
     test('地上波はリモコン番号順。同じ番号ならサービスID順', () => {
-        database().query('DELETE FROM services').run();
+        orm().delete(services).run();
         put(3273601025, 1025, 'GR', 'T27', 1, 'NHK総合2');
         put(3273601024, 1024, 'GR', 'T27', 1, 'NHK総合1');
         put(3239123608, 23608, 'GR', 'T16', 9, 'TOKYO MX1');
@@ -366,7 +482,7 @@ describe('SERVICE_ORDER', () => {
     });
 
     test('地上波 → BS → CS の順。テレビの切り替えもこの順', () => {
-        database().query('DELETE FROM services').run();
+        orm().delete(services).run();
         put(400151, 151, 'BS', 'BS01_3', null, 'BS朝日1');
         put(600292, 292, 'CS', 'CS04', null, '時代劇専門ch');
         put(3239123608, 23608, 'GR', 'T16', 9, 'TOKYO MX1');

--- a/src/lib/server/epg.ts
+++ b/src/lib/server/epg.ts
@@ -1,7 +1,7 @@
-import { and, count, eq, gt, inArray, isNull, lt, ne, sql } from 'drizzle-orm';
+import { and, count, eq, gt, inArray, isNull, lt, ne, or, sql } from 'drizzle-orm';
 import type { EitEvent } from '../ts/eit';
 import { config } from './config';
-import { affected, database, now, orm } from './db';
+import { affected, now, orm } from './db';
 import { emit } from './events';
 import { applyRules } from './rules';
 import { resolveConflicts } from './scheduler';
@@ -370,23 +370,32 @@ export function savePrograms(events: EitEvent[]): number {
  * そのまま録画の名前になっていた。
  */
 function syncReservationTimes(): number {
-    const changed = database()
-        .prepare(
-            `
-        UPDATE reservations
-        SET start_at = p.start_at, end_at = p.end_at, name = p.name,
-            description = p.description, updated_at = ?
-        FROM programs p
-        WHERE p.id = reservations.program_id
-          AND reservations.state IN ('scheduled', 'conflict')
-          -- 録り始めた予約は動かさない。延長への追従は録画の行のほうでやる
-          AND reservations.started_at IS NULL
-          AND (reservations.start_at != p.start_at OR reservations.end_at != p.end_at
-               OR reservations.name != p.name OR reservations.description != p.description)
-    `,
-        )
-        .run(now());
-    return changed.changes;
+    return affected(
+        orm()
+            .update(reservations)
+            .set({
+                start_at: programs.start_at,
+                end_at: programs.end_at,
+                name: programs.name,
+                description: programs.description,
+                updated_at: now(),
+            })
+            .from(programs)
+            .where(
+                and(
+                    eq(programs.id, reservations.program_id),
+                    inArray(reservations.state, ['scheduled', 'conflict']),
+                    // 録り始めた予約は動かさない。延長への追従は録画の行のほうでやる
+                    isNull(reservations.started_at),
+                    or(
+                        ne(reservations.start_at, programs.start_at),
+                        ne(reservations.end_at, programs.end_at),
+                        ne(reservations.name, programs.name),
+                        ne(reservations.description, programs.description),
+                    ),
+                ),
+            ),
+    );
 }
 
 /** 終わった番組を消す。番組表は未来しか見ないので、直近の分だけ残せば足りる */

--- a/src/lib/server/files.test.ts
+++ b/src/lib/server/files.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { eq, sql } from 'drizzle-orm';
 
 /**
  * 古い履歴の片付け。
@@ -16,68 +17,107 @@ const { config } = await import('./config');
 config.dbPath = join(mkdtempSync(join(tmpdir(), 'denpa-files-')), 'denpa.db');
 config.historyRetention = 14 * 24 * 60 * 60 * 1000;
 
-const { database } = await import('./db');
+const { orm } = await import('./db');
+const { encodeJobs, recordings, reservations } = await import('./schema');
 const { pruneHistory, reconcile } = await import('./files');
 
 const DAY = 24 * 60 * 60 * 1000;
 const now = Date.now();
 
 function seed(): void {
-    const db = database();
-    db.exec('DELETE FROM reservations; DELETE FROM recordings; DELETE FROM encode_jobs');
+    orm().delete(reservations).run();
+    orm().delete(recordings).run();
+    orm().delete(encodeJobs).run();
 
     /*
      * 「終わった予約」は取り消し・録り逃しか、録り始めたもの (started_at が入る)。
      * 予約の行に 'done' や 'failed' は入らない — 顛末は録画の行が持っている
      */
-    const reservation = db.prepare(
-        `INSERT INTO reservations (id, program_id, service_id, name, start_at, end_at, state, started_at, created_at, updated_at)
-         VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?)`,
-    );
-    reservation.run(1, 1, '古い完了', now - 30 * DAY, now - 30 * DAY, 'scheduled', now - 30 * DAY, now, now);
-    reservation.run(2, 2, '古い取り消し', now - 30 * DAY, now - 30 * DAY, 'canceled', null, now, now);
-    reservation.run(3, 3, 'これから', now + DAY, now + DAY, 'scheduled', null, now, now);
-    reservation.run(4, 4, '最近の完了', now - DAY, now - DAY, 'scheduled', now - DAY, now, now);
+    const reservation = (
+        id: number,
+        name: string,
+        at: number,
+        state: 'scheduled' | 'canceled',
+        started_at: number | null,
+    ) => ({
+        id,
+        program_id: id,
+        service_id: 1,
+        name,
+        start_at: at,
+        end_at: at,
+        state,
+        started_at,
+        created_at: now,
+        updated_at: now,
+    });
+    orm()
+        .insert(reservations)
+        .values([
+            reservation(1, '古い完了', now - 30 * DAY, 'scheduled', now - 30 * DAY),
+            reservation(2, '古い取り消し', now - 30 * DAY, 'canceled', null),
+            reservation(3, 'これから', now + DAY, 'scheduled', null),
+            reservation(4, '最近の完了', now - DAY, 'scheduled', now - DAY),
+        ])
+        .run();
 
     // state は生成列なので入れられない。録り終えた時刻と保存先で「視聴可能」になる
-    const recording = db.prepare(
-        `INSERT INTO recordings (id, service_id, name, start_at, end_at, finished_at, library_path, deleted_at, created_at, updated_at)
-         VALUES (?, 1, ?, ?, ?, ?, '/library/x.mkv', ?, ?, ?)`,
-    );
-    recording.run(
-        1,
-        '古い削除済み',
-        now - 30 * DAY,
-        now - 30 * DAY,
-        now - 30 * DAY,
-        now - 30 * DAY,
-        now,
-        now,
-    );
-    recording.run(2, '最近の削除済み', now - DAY, now - DAY, now - DAY, now - DAY, now, now);
-    recording.run(3, '残っている録画', now - 30 * DAY, now - 30 * DAY, now - 30 * DAY, null, now, now);
+    const recording = (id: number, name: string, at: number, deleted_at: number | null) => ({
+        id,
+        service_id: 1,
+        name,
+        start_at: at,
+        end_at: at,
+        finished_at: at,
+        library_path: '/library/x.mkv',
+        deleted_at,
+        created_at: now,
+        updated_at: now,
+    });
+    orm()
+        .insert(recordings)
+        .values([
+            recording(1, '古い削除済み', now - 30 * DAY, now - 30 * DAY),
+            recording(2, '最近の削除済み', now - DAY, now - DAY),
+            recording(3, '残っている録画', now - 30 * DAY, null),
+        ])
+        .run();
 
-    const job = db.prepare(
-        `INSERT INTO encode_jobs (id, recording_id, state, created_at, finished_at) VALUES (?, ?, ?, ?, ?)`,
-    );
-    // 消える録画にぶら下がっているもの
-    job.run(1, 1, 'done', now, now);
-    // 残る録画の、古い失敗と新しい成功。古いほうだけ消えて、最新は残る
-    job.run(2, 3, 'failed', now - 30 * DAY, now - 30 * DAY);
-    job.run(3, 3, 'done', now - 30 * DAY, now - 30 * DAY);
+    const job = (id: number, recording_id: number, state: 'done' | 'failed', at: number) => ({
+        id,
+        recording_id,
+        state,
+        created_at: at,
+        finished_at: at,
+    });
+    orm()
+        .insert(encodeJobs)
+        .values([
+            // 消える録画にぶら下がっているもの
+            job(1, 1, 'done', now),
+            // 残る録画の、古い失敗と新しい成功。古いほうだけ消えて、最新は残る
+            job(2, 3, 'failed', now - 30 * DAY),
+            job(3, 3, 'done', now - 30 * DAY),
+        ])
+        .run();
 }
 
-const ids = (table: string) =>
-    (database().query(`SELECT id FROM ${table} ORDER BY id`).all() as { id: number }[]).map((row) => row.id);
+const ids = (table: typeof reservations | typeof recordings | typeof encodeJobs) =>
+    orm()
+        .select({ id: sql<number>`id` })
+        .from(table)
+        .orderBy(sql`id`)
+        .all()
+        .map((row) => row.id);
 
 describe('古い履歴の片付け', () => {
     test('2週間より古い「終わったもの」だけ消える', () => {
         seed();
         expect(pruneHistory()).toEqual({ reservations: 2, recordings: 1, jobs: 1 });
         // 残るのは「これから」と最近のもの
-        expect(ids('reservations')).toEqual([3, 4]);
+        expect(ids(reservations)).toEqual([3, 4]);
         // ファイルが残っている録画は、古くても消さない
-        expect(ids('recordings')).toEqual([2, 3]);
+        expect(ids(recordings)).toEqual([2, 3]);
     });
 
     test('録画の行と一緒にエンコードの記録も消える', () => {
@@ -85,7 +125,7 @@ describe('古い履歴の片付け', () => {
         pruneHistory();
         // 1 は録画ごと消えた。2 は古い失敗なので消える。
         // 3 はその録画の最新なので、古くても残す (一覧の状態表示がこれを見ている)
-        expect(ids('encode_jobs')).toEqual([3]);
+        expect(ids(encodeJobs)).toEqual([3]);
     });
 
     test('何度やっても同じ', () => {
@@ -129,7 +169,7 @@ describe('実体との照合', () => {
         config.libraryDir = join(root, 'library');
         mkdirSync(config.recordedDir, { recursive: true });
         mkdirSync(config.libraryDir, { recursive: true });
-        database().exec('DELETE FROM recordings');
+        orm().delete(recordings).run();
     }
 
     /*
@@ -270,12 +310,21 @@ describe('実体との照合', () => {
     function twoCodec(): { av1: string; h264: string } {
         const av1 = put(config.libraryDir, '二本立て/二本立て - 1.mkv');
         const h264 = put(config.libraryDir, '二本立て/二本立て - 1 [H264].mkv');
-        database()
-            .prepare(
-                `INSERT INTO recordings (id, service_id, name, start_at, end_at, finished_at, library_path, alt_path, created_at, updated_at)
-                 VALUES (9, 1, '二本立て', 0, 0, 0, ?, ?, 0, 0)`,
-            )
-            .run(av1, h264);
+        orm()
+            .insert(recordings)
+            .values({
+                id: 9,
+                service_id: 1,
+                name: '二本立て',
+                start_at: 0,
+                end_at: 0,
+                finished_at: 0,
+                library_path: av1,
+                alt_path: h264,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .run();
         return { av1, h264 };
     }
 
@@ -301,9 +350,11 @@ describe('実体との照合', () => {
         const result = reconcile();
         // 削除済みには倒さない
         expect(result.removed).toBe(0);
-        const row = database()
-            .query('SELECT library_path AS lib, alt_path AS alt FROM recordings WHERE id = 9')
-            .get() as { lib: string; alt: string | null };
+        const row = orm()
+            .select({ lib: recordings.library_path, alt: recordings.alt_path })
+            .from(recordings)
+            .where(eq(recordings.id, 9))
+            .get()!;
         expect(row.lib).toBe(h264);
         expect(row.alt).toBeNull();
     });
@@ -316,9 +367,11 @@ describe('実体との照合', () => {
 
         const result = reconcile();
         expect(result.removed).toBe(0);
-        const row = database()
-            .query('SELECT library_path AS lib, alt_path AS alt FROM recordings WHERE id = 9')
-            .get() as { lib: string; alt: string | null };
+        const row = orm()
+            .select({ lib: recordings.library_path, alt: recordings.alt_path })
+            .from(recordings)
+            .where(eq(recordings.id, 9))
+            .get()!;
         expect(row.lib).toBe(av1);
         expect(row.alt).toBeNull();
     });

--- a/src/lib/server/recorded-bml.test.ts
+++ b/src/lib/server/recorded-bml.test.ts
@@ -19,7 +19,8 @@ import type { Recording } from '../types';
 // DB は一時ファイルへ (番組の名乗りを組むのに services を引く。files.test.ts と同じ手)
 const { config } = await import('./config');
 config.dbPath = join(mkdtempSync(join(tmpdir(), 'denpa-bml-db-')), 'denpa.db');
-const { database } = await import('./db');
+const { orm } = await import('./db');
+const { services } = await import('./schema');
 const { loadRecordedBml, saveRecordedBml, withProgramInfo } = await import('./recorded-bml');
 
 /*
@@ -46,19 +47,25 @@ const dir = mkdtempSync(join(tmpdir(), 'denpa-bml-'));
 afterAll(() => {
     rmSync(dir, { recursive: true, force: true });
     // DB は同じプロセスの他のテストと共有になりうる (最初に開いた1本を使い回す)。入れた局は片付ける
-    database().exec('DELETE FROM services');
+    orm().delete(services).run();
 });
 
 const T = Date.UTC(2026, 7, 12, 0, 0, 30);
 
 /** 録画の行の要るところだけ。局は services に 1 つ入れておく (network 4, service 1024) */
 function recording(startAt: number): Recording {
-    database().exec('DELETE FROM services');
-    database()
-        .prepare(
-            `INSERT INTO services (id, service_id, network_id, name, type, channel, updated_at)
-             VALUES (7, 1024, 4, 'テスト局', 'GR', 'T27', 0)`,
-        )
+    orm().delete(services).run();
+    orm()
+        .insert(services)
+        .values({
+            id: 7,
+            service_id: 1024,
+            network_id: 4,
+            name: 'テスト局',
+            type: 'GR',
+            channel: 'T27',
+            updated_at: 0,
+        })
         .run();
     return {
         id: 1,

--- a/src/lib/server/relayout.test.ts
+++ b/src/lib/server/relayout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { eq } from 'drizzle-orm';
 
 /**
  * 旧レイアウト (Season フォルダ + episodedetails + `-thumb.jpg`) をいまの形
@@ -11,7 +12,8 @@ const { config } = await import('./config');
 config.dbPath = join(mkdtempSync(join(tmpdir(), 'denpa-relayout-')), 'denpa.db');
 config.libraryDir = mkdtempSync(join(tmpdir(), 'denpa-relayout-lib-'));
 
-const { database } = await import('./db');
+const { orm } = await import('./db');
+const { recordings } = await import('./schema');
 const { relayoutLibrary } = await import('./relayout');
 
 const START = new Date(2026, 7, 12, 0, 0).getTime();
@@ -23,42 +25,43 @@ function put(rel: string, content = 'x'): string {
     return path;
 }
 
-function insert(over: Record<string, unknown>): void {
-    const row = {
-        id: 1,
-        service_name: 'テレ東',
-        name: '番組',
-        series: '番組',
-        subtitle: '',
-        description: '概要',
-        start_at: START,
-        library_path: null,
-        alt_path: null,
-        ...over,
-    };
-    database()
-        .prepare(
-            `INSERT INTO recordings
-             (id, service_id, service_name, name, series, subtitle, description, start_at, end_at, finished_at, library_path, alt_path, created_at, updated_at)
-             VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)`,
-        )
-        .run(
-            row.id,
-            row.service_name,
-            row.name,
-            row.series,
-            row.subtitle,
-            row.description,
-            row.start_at,
-            row.start_at,
-            row.start_at,
-            row.library_path,
-            row.alt_path,
-        );
+const DEFAULTS = {
+    id: 1,
+    service_name: 'テレ東',
+    name: '番組',
+    series: '番組',
+    subtitle: '',
+    description: '概要',
+    start_at: START,
+    library_path: null as string | null,
+    alt_path: null as string | null,
+};
+
+function insert(over: Partial<typeof DEFAULTS>): void {
+    const row = { ...DEFAULTS, ...over };
+    orm()
+        .insert(recordings)
+        .values({
+            id: row.id,
+            service_id: 1,
+            service_name: row.service_name,
+            name: row.name,
+            series: row.series,
+            subtitle: row.subtitle,
+            description: row.description,
+            start_at: row.start_at,
+            end_at: row.start_at,
+            finished_at: row.start_at,
+            library_path: row.library_path,
+            alt_path: row.alt_path,
+            created_at: 0,
+            updated_at: 0,
+        })
+        .run();
 }
 
 function reset(): void {
-    database().exec('DELETE FROM recordings');
+    orm().delete(recordings).run();
     // 実体もまっさらに戻す (テストは同じ libraryDir を使い回すので、前のテストの
     // 残りが「新しい置き場が既に埋まっている」= 衝突として効いてしまう)
     rmSync(config.libraryDir, { recursive: true, force: true });
@@ -66,9 +69,11 @@ function reset(): void {
 }
 
 function libPath(id: number): { lib: string | null; alt: string | null } {
-    return database()
-        .query('SELECT library_path AS lib, alt_path AS alt FROM recordings WHERE id = ?')
-        .get(id) as { lib: string | null; alt: string | null };
+    return orm()
+        .select({ lib: recordings.library_path, alt: recordings.alt_path })
+        .from(recordings)
+        .where(eq(recordings.id, id))
+        .get()!;
 }
 
 const OLD_DIR = '番組/Season 2026';

--- a/src/lib/server/rules-apply.test.ts
+++ b/src/lib/server/rules-apply.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
 
 /**
  * ルールを番組表に当て直して、予約をそろえるところ。
@@ -13,20 +14,26 @@ import { join } from 'node:path';
 const { config } = await import('./config');
 config.dbPath = join(mkdtempSync(join(tmpdir(), 'denpa-rules-')), 'denpa.db');
 
-const { database, now } = await import('./db');
+const { now, orm } = await import('./db');
 const { applyRules } = await import('./rules');
+const { programs, reservations: reservationTable, rules: ruleTable, services } = await import('./schema');
 
 const SERVICE = 3239123608;
 const HOUR = 60 * 60 * 1000;
 
-const CLEAR = 'DELETE FROM reservations; DELETE FROM programs; DELETE FROM rules; DELETE FROM services';
+function clear(): void {
+    orm().delete(reservationTable).run();
+    orm().delete(programs).run();
+    orm().delete(ruleTable).run();
+    orm().delete(services).run();
+}
 
 /*
  * **置いたものは持って帰る。** bun test はファイルをまたいでモジュールを使い回すので、
  * DBの接続も1つ (`db.database`)。先に開いたファイルの置き場が全員のものになるため、
  * 行を残すと隣のファイルの「まだ空のはず」が崩れる (実機ならぬCIで epg.test.ts が落ちた)
  */
-afterAll(() => database().exec(CLEAR));
+afterAll(clear);
 
 /**
  * 番組を置く基準の時刻。**`reset()` のたびに1回だけ読む。**
@@ -39,47 +46,76 @@ let base = now();
 
 function reset(): void {
     base = now();
-    const db = database();
-    db.exec(CLEAR);
-    db.prepare(
-        `INSERT INTO services (id, service_id, network_id, name, type, service_type, channel, has_logo, updated_at)
-         VALUES (?, 23608, 32391, 'TOKYO MX1', 'GR', 1, 'T16', 0, ?)`,
-    ).run(SERVICE, now());
+    clear();
+    sub(SERVICE, 'TOKYO MX1');
+}
+
+/** 局を1つ置く (置き直し)。MX の枝番も同じ物理チャンネルに乗る */
+function sub(id: number, name: string, channel = 'T16'): void {
+    orm().delete(services).where(eq(services.id, id)).run();
+    orm()
+        .insert(services)
+        .values({
+            id,
+            service_id: id % 100000,
+            network_id: 32391,
+            name,
+            type: 'GR',
+            service_type: 1,
+            channel,
+            updated_at: now(),
+        })
+        .run();
+}
+
+/** 局を指定して番組を1つ置く (置き直し)。既定は3時間後から (猶予の外) */
+function on(serviceId: number, id: number, name: string, startsIn = 3 * HOUR): void {
+    const start = base + startsIn;
+    orm().delete(programs).where(eq(programs.id, id)).run();
+    orm()
+        .insert(programs)
+        .values({
+            id,
+            service_id: serviceId,
+            network_id: 32391,
+            event_id: id,
+            start_at: start,
+            end_at: start + HOUR,
+            name,
+            updated_at: now(),
+        })
+        .run();
 }
 
 /** 番組を1つ置く。既定は3時間後から (猶予の外) */
 function program(id: number, name: string, startsIn = 3 * HOUR): void {
-    const start = base + startsIn;
-    database()
-        .prepare(
-            `INSERT OR REPLACE INTO programs
-                (id, service_id, network_id, event_id, start_at, end_at, name, description, is_free, updated_at)
-             VALUES (?, ?, 32391, ?, ?, ?, ?, '', 1, ?)`,
-        )
-        .run(id, SERVICE, id, start, start + HOUR, name, now());
+    on(SERVICE, id, name, startsIn);
 }
 
-function rule(id: number, keyword: string, enabled = 1, priority = 1): void {
-    database()
-        .prepare(
-            `INSERT OR REPLACE INTO rules
-                (id, name, keyword, ignore_keyword, search_fields, service_ids, service_types,
-                 genres, enabled, priority, created_at)
-             VALUES (?, ?, ?, '', 'name', NULL, NULL, NULL, ?, ?, ?)`,
-        )
-        .run(id, keyword, keyword, enabled, priority, now());
+function rule(id: number, keyword: string, enabled = true, priority = 1): void {
+    orm().delete(ruleTable).where(eq(ruleTable.id, id)).run();
+    orm()
+        .insert(ruleTable)
+        .values({ id, name: keyword, keyword, search_fields: 'name', enabled, priority, created_at: now() })
+        .run();
 }
 
 const priorityOf = (programId: number): number | undefined =>
-    database()
-        .query<{ priority: number }, [number]>('SELECT priority FROM reservations WHERE program_id = ?')
-        .get(programId)?.priority;
+    orm()
+        .select({ priority: reservationTable.priority })
+        .from(reservationTable)
+        .where(eq(reservationTable.program_id, programId))
+        .get()?.priority;
 
 const reservations = () =>
-    database()
-        .query<{ program_id: number; rule_id: number | null; state: string }, []>(
-            'SELECT program_id, rule_id, state FROM reservations ORDER BY program_id',
-        )
+    orm()
+        .select({
+            program_id: reservationTable.program_id,
+            rule_id: reservationTable.rule_id,
+            state: reservationTable.state,
+        })
+        .from(reservationTable)
+        .orderBy(reservationTable.program_id)
         .all();
 
 describe('ルールを当て直す', () => {
@@ -109,7 +145,7 @@ describe('ルールを当て直す', () => {
         applyRules();
         expect(priorityOf(10)).toBe(1);
 
-        rule(1, '無職転生', 1, 2);
+        rule(1, '無職転生', true, 2);
         expect(applyRules()).toEqual({ created: 0, dropped: 0, moved: 0, repriced: 1 });
         expect(priorityOf(10)).toBe(2);
 
@@ -140,7 +176,11 @@ describe('ルールを当て直す', () => {
         rule(1, '無職転生');
         program(10, '無職転生Ⅲ #6');
         applyRules();
-        database().prepare("UPDATE reservations SET state = 'canceled' WHERE program_id = 10").run();
+        orm()
+            .update(reservationTable)
+            .set({ state: 'canceled' })
+            .where(eq(reservationTable.program_id, 10))
+            .run();
 
         expect(applyRules()).toMatchObject({ created: 0, dropped: 0 });
         expect(reservations()).toEqual([{ program_id: 10, rule_id: 1, state: 'canceled' }]);
@@ -149,13 +189,20 @@ describe('ルールを当て直す', () => {
     test('手動の予約は触らない', () => {
         reset();
         program(10, '手で入れた番組');
-        database()
-            .prepare(
-                `INSERT INTO reservations (program_id, rule_id, service_id, name, description,
-                    start_at, end_at, manual, state, created_at, updated_at)
-                 VALUES (10, NULL, ?, '手で入れた番組', '', ?, ?, 1, 'scheduled', ?, ?)`,
-            )
-            .run(SERVICE, now() + 3 * HOUR, now() + 4 * HOUR, now(), now());
+        orm()
+            .insert(reservationTable)
+            .values({
+                program_id: 10,
+                rule_id: null,
+                service_id: SERVICE,
+                name: '手で入れた番組',
+                start_at: now() + 3 * HOUR,
+                end_at: now() + 4 * HOUR,
+                manual: true,
+                created_at: now(),
+                updated_at: now(),
+            })
+            .run();
 
         expect(applyRules()).toMatchObject({ dropped: 0 });
         expect(reservations()).toHaveLength(1);
@@ -166,7 +213,11 @@ describe('ルールを当て直す', () => {
         rule(1, '無職転生');
         program(10, '無職転生Ⅲ #6');
         applyRules();
-        database().prepare('UPDATE reservations SET started_at = ? WHERE program_id = 10').run(now());
+        orm()
+            .update(reservationTable)
+            .set({ started_at: now() })
+            .where(eq(reservationTable.program_id, 10))
+            .run();
         program(10, '差し替え');
 
         expect(applyRules()).toMatchObject({ dropped: 0 });
@@ -183,7 +234,7 @@ describe('ルールを当て直す', () => {
         rule(1, '無職転生');
         program(10, '無職転生Ⅲ #6');
         applyRules();
-        database().prepare('DELETE FROM programs WHERE id = 10').run();
+        orm().delete(programs).where(eq(programs.id, 10)).run();
 
         expect(applyRules()).toMatchObject({ dropped: 0 });
         expect(reservations()).toHaveLength(1);
@@ -222,7 +273,7 @@ describe('ルールを当て直す', () => {
         rule(1, '無職転生');
         program(10, '無職転生Ⅲ #6', 10 * 60 * 1000);
         applyRules();
-        rule(1, '無職転生', 0);
+        rule(1, '無職転生', false);
 
         expect(applyRules()).toMatchObject({ dropped: 1 });
         expect(reservations()).toEqual([]);
@@ -237,7 +288,7 @@ describe('ルールを当て直す', () => {
         expect(reservations()).toEqual([{ program_id: 10, rule_id: 1, state: 'scheduled' }]);
 
         // 1 を消した。2 がまだ当たるので、予約は生き続ける
-        database().prepare('DELETE FROM rules WHERE id = 1').run();
+        orm().delete(ruleTable).where(eq(ruleTable.id, 1)).run();
 
         expect(applyRules()).toMatchObject({ dropped: 0, moved: 1 });
         expect(reservations()).toEqual([{ program_id: 10, rule_id: 2, state: 'scheduled' }]);
@@ -248,7 +299,7 @@ describe('ルールを当て直す', () => {
         rule(1, '無職転生');
         program(10, '無職転生Ⅲ #6');
         applyRules();
-        database().prepare('DELETE FROM rules WHERE id = 1').run();
+        orm().delete(ruleTable).where(eq(ruleTable.id, 1)).run();
 
         expect(applyRules()).toMatchObject({ dropped: 1 });
         expect(reservations()).toEqual([]);
@@ -286,28 +337,6 @@ describe('ルールを当て直す', () => {
  */
 describe('同じ放送は1本だけ', () => {
     const MX2 = 3239123610;
-
-    function sub(id: number, name: string, channel = 'T16'): void {
-        database()
-            .prepare(
-                `INSERT OR REPLACE INTO services
-                    (id, service_id, network_id, name, type, service_type, channel, has_logo, updated_at)
-                 VALUES (?, ?, 32391, ?, 'GR', 1, ?, 0, ?)`,
-            )
-            .run(id, id % 100000, name, channel, now());
-    }
-
-    /** 局を指定して番組を1つ置く */
-    function on(serviceId: number, id: number, name: string, startsIn = 3 * HOUR): void {
-        const start = base + startsIn;
-        database()
-            .prepare(
-                `INSERT OR REPLACE INTO programs
-                    (id, service_id, network_id, event_id, start_at, end_at, name, description, is_free, updated_at)
-                 VALUES (?, ?, 32391, ?, ?, ?, ?, '', 1, ?)`,
-            )
-            .run(id, serviceId, id, start, start + HOUR, name, now());
-    }
 
     test('枝番の小さいほうだけ録る', () => {
         reset();


### PR DESCRIPTION
## 何を

単体テストに残っていた生 SQL (`database().prepare()` で行を作る) を `orm()` に寄せ、本体で最後に残っていた生 SQL (`epg.ts` の予約の追従、`UPDATE … FROM`) も drizzle にしました (#47 の続きで挙げた「試験の生 SQL」)。

### 試験 (6 本)

`rules-apply` / `epg` / `files` / `relayout` / `encoder-pump` / `recorded-bml` の行の用意を `orm().insert(...).values({...})` に。列を足したり型を変えたりしたときに、試験の側も TS が言ってくれるようになります (前は SQL の文字列なので実行して初めて分かった)。

- `INSERT OR REPLACE` は「消してから入れる」に (drizzle には無い)
- 生成列 (`recordings.state`) は入れない。前と同じで、録り終えた時刻と保存先から決まる
- `schema.test.ts` だけは生のまま。PRAGMA で列を突き合わせる試験と、壊れた文字列を入れて読み手を見る試験なので、生でないと意味が無い
- `epg.test.ts` の `extended` の期待値は、JSON 列が #44 でオブジェクトになったのに合わせて `{ 番組内容: 'あらすじ' }` に (前は生 SQL で読んでいたので文字列のままだった)

### 本体 (`epg.ts`)

`syncReservationTimes` の `UPDATE reservations … FROM programs` を `orm().update(reservations).set({ start_at: programs.start_at, … }).from(programs).where(…)` に。**これで生 SQL の口は無くなりました** (`database()` を本体で直に使うのは `db.ts` だけ)。

この関数には試験が無かったので足しました: 番組表が動いたら、まだ始めていない予約だけ時刻と名前が追従し、録り始めた予約は動かない。二度目は 0 件。

## 確かめたこと

- `biome check .` / `svelte-check` 0 エラー
- 単体 804 本 (追従の試験 1 本を追加)
- e2e 全体

🤖 Generated with [Claude Code](https://claude.com/claude-code)
