### PR TITLE
test: e2e の揺れの大半だった Chromium の GPU プロセスの SEGV を避ける

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "denpa",
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",
-        "@playwright/test": "1.63.0",
+        "@playwright/test": "^1.63.0",
         "@sveltejs/adapter-node": "^5.4.0",
         "@sveltejs/kit": "^2.49.2",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "denpa",
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "1.63.0",
         "@sveltejs/adapter-node": "^5.4.0",
         "@sveltejs/kit": "^2.49.2",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -123,7 +123,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
-    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
+    "@playwright/test": ["@playwright/test@1.63.0", "", { "dependencies": { "playwright": "1.63.0" }, "bin": { "playwright": "cli.js" } }, "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -391,9 +391,9 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+    "playwright": ["playwright@1.63.0", "", { "dependencies": { "playwright-core": "1.63.0" }, "bin": { "playwright": "cli.js" } }, "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg=="],
 
-    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+    "playwright-core": ["playwright-core@1.63.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg=="],
 
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
@@ -468,8 +468,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "tsx/esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "license": "AGPL-3.0-or-later",
     "devDependencies": {
         "@biomejs/biome": "^2.5.6",
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "^1.63.0",
         "@sveltejs/adapter-node": "^5.4.0",
         "@sveltejs/kit": "^2.49.2",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,5 +34,13 @@ export default defineConfig({
         // 「端末に合わせる」がダークになる前提でテストする
         colorScheme: 'dark',
         trace: 'retain-on-failure',
+        /*
+         * **GPU プロセスを起こさない。** CI でも手元 (WSL) でも GPU は無く
+         * (`drmGetDevices2() has not found any devices`)、それでも起こしに行った
+         * GPU プロセスが `browser.newContext` の途中で SEGV (`SEGV_MAPERR 0000000001b0`、
+         * 毎回同じ番地) して、テストが「ブラウザが閉じられた」で落ちていた。
+         * CI の直近 6 回のうち 4 回で、揺れの大半がこれ
+         */
+        launchOptions: { args: ['--disable-gpu'] },
     },
 });


### PR DESCRIPTION
## 何を

e2e の揺れ (#47 の続きで挙げた最後の 1 つ) の原因を CI ログ 6 回ぶんと手元の実行から集めて、大半を占めていた 1 つを手当てしました。

## 分かったこと

CI の直近 6 回の e2e (24 ジョブ) で 1 回目に落ちて再試行で通ったのは 6 件。うち **4 件は同じ Chromium のクラッシュ**です:

```
Error: browser.newContext: Target page, context or browser has been closed
[err] [WARNING:media/gpu/vaapi/vaapi_wrapper.cc:1655] drmGetDevices2() has not found any devices
[err] [WARNING:sandbox/policy/linux/sandbox_linux.cc:405] InitializeSandbox() called with multiple threads in process gpu-process.
[err] Received signal 11 SEGV_MAPERR 0000000001b0
```

GPU の無い環境で起こした GPU プロセスが、毎回同じ番地で死んでいます (01-dashboard / 05-rules ×2 / 17-logo で、どのテストかは関係なく `newContext` の瞬間)。手元 (WSL) で今日出ていた `browser.newContext … closed` も同じログでした。

残り 2 件 (17-logo「見切って数える」の 90 秒待ち、20-live「その局だけの TS」の 15 秒待ち) は、同じジョブで直前にこのクラッシュが起きて再試行で混んでいたときの出方なので、まずこれを消してから見ます。

## 手当て

- `playwright.config.ts` に `launchOptions: { args: ['--disable-gpu'] }`。headless で GPU は要らず、起こさなければ死にようがない
- `@playwright/test` を 1.62 → 1.63 (Chromium 153)。同じ番地で落ちる版から離れる。lock は Renovate が追っていた 1.62.1 で、`package.json` の範囲だけ古かったので合わせました

**確かめ方は CI の回数です。** 手元で 1 回通っても証拠にならないので (元から 1 回目に落ちるのは数十回に 1 度)、この後の PR の CI で `browser.newContext` の落ちが出なくなるかで見ます。手元では全体を 1 回通しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
