### PR TITLE
refactor: 新しい版の知らせは、リリースのイメージに版を 1 層足して数で比べる

### DIFF
--- a/.github/release.Dockerfile
+++ b/.github/release.Dockerfile
@@ -1,0 +1,11 @@
+# リリースのイメージ。**main で組んだイメージに、版を 1 層足すだけ。**
+#
+# 組み直さない (組み直すと apt の中身が main のものとずれうる)。中身の層は
+# `sha-…` のイメージと同じで、増えるのは ENV のメタデータ 1 枚。数秒で終わる。
+# 動いている denpa はこの版と GitHub の最新のリリースを数で比べて、新しい版の
+# 知らせを出す (src/lib/server/update.ts)。main (develop) のイメージは版を持たず
+# (`dev`)、知らせも出さない — main を追いかけている限りリリースより常に先
+ARG BASE
+FROM ${BASE}
+ARG DENPA_VERSION
+ENV DENPA_VERSION=${DENPA_VERSION}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -91,10 +91,6 @@ jobs:
           pull: true
           cache-from: type=gha,scope=denpa
           cache-to: type=gha,mode=max,scope=denpa
-          # 動いているコミットとして焼き込む。新しい版の知らせは、GitHub の最新の
-          # リリースがこれより先かを見て出す (src/lib/server/update.ts)
-          build-args: |
-            DENPA_COMMIT=${{ github.sha }}
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/denpa:${{ steps.tag.outputs.denpa }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/denpa:develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # `imagetools create` はイメージを引かずに、レジストリの中で名前を足すだけ。
-      # 元のイメージが無ければここで落ちる (黙って古い latest が残るより、そのほうがいい)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # エージェントは `imagetools create` — イメージを引かずに、レジストリの中で名前を
+      # 足すだけ。元のイメージが無ければここで落ちる (黙って古い latest が残るより、
+      # そのほうがいい)。
+      #
+      # denpa は**版を 1 層足して**から名前を付ける (.github/release.Dockerfile)。
+      # main で組んだイメージを土台にするので中身は同じで、増えるのは ENV の 1 枚。
+      # 動いている denpa はこれで自分の版を知り、新しい版の知らせを出す
       - name: Point the names at this release
         run: |
           set -eu
@@ -106,17 +114,23 @@ jobs:
             echo "貼る名前がありません (x.y.z ではなく、試し版でもない)" >&2
             exit 1
           fi
-          for image in "denpa-agent:${{ steps.tag.outputs.agent }}" "denpa:${{ steps.tag.outputs.denpa }}"; do
-            name="${image%%:*}"
-            args=""
-            for alias in $names; do
-              args="$args --tag ${base}/${name}:${alias}"
-            done
-            # 単語に割りたいので引用しない (中身は上で作った名前だけ)
-            # shellcheck disable=SC2086
-            docker buildx imagetools create $args "${base}/${image}"
-            echo "${name}: ${image#*:} → $names"
+          agent_args=""
+          denpa_args=""
+          for alias in $names; do
+            agent_args="$agent_args --tag ${base}/denpa-agent:${alias}"
+            denpa_args="$denpa_args --tag ${base}/denpa:${alias}"
           done
+          # 単語に割りたいので引用しない (中身は上で作った名前だけ)
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $agent_args "${base}/denpa-agent:${{ steps.tag.outputs.agent }}"
+          echo "denpa-agent: ${{ steps.tag.outputs.agent }} → $names"
+          # shellcheck disable=SC2086
+          docker buildx build --push \
+            --file .github/release.Dockerfile \
+            --build-arg BASE="${base}/denpa:${{ steps.tag.outputs.denpa }}" \
+            --build-arg DENPA_VERSION="${{ github.event.release.tag_name || github.event.inputs.ref }}" \
+            $denpa_args .
+          echo "denpa: ${{ steps.tag.outputs.denpa }} + DENPA_VERSION → $names"
 
   # **Helm chart もリリースのたびに出す** (README が案内している `oci://ghcr.io/danything/charts/…`)。
   # chart の版 (Chart.yaml の version) とアプリの版 (appVersion) をリリースの

--- a/Dockerfile
+++ b/Dockerfile
@@ -216,10 +216,9 @@ COPY --from=build /app/drizzle ./drizzle
 COPY --from=build /app/server.js ./server.js
 
 EXPOSE 3000
-# 動いているコミット。CI が入れる。手元で組むと dev。新しい版の知らせは、GitHub の
-# 最新のリリースがこのコミットより先かを見て出す (src/lib/server/update.ts)。
-# **いちばん最後に置く** — コミットが変わるだけで上の層を組み直さないため
-ARG DENPA_COMMIT=dev
-ENV DENPA_COMMIT=${DENPA_COMMIT}
+# 動いている版。ここでは `dev` のまま — リリースのときに、このイメージを土台に
+# 版を 1 層足す (.github/release.Dockerfile)。新しい版の知らせはそれと GitHub の
+# 最新のリリースを数で比べて出す (src/lib/server/update.ts)。dev では出さない
+ENV DENPA_VERSION=dev
 
 CMD ["bun", "./server.js"]

--- a/docs/app.md
+++ b/docs/app.md
@@ -173,8 +173,8 @@ SQLite が拒むので、事実と状態が食い違いようがありません�
 | `RECORDED_DIR` | `/app/recorded` | 生TSの作業領域 |
 | `LIBRARY_DIR` | `/library` | エンコード済みの置き場。ここから配る |
 | `FFMPEG` / `FFPROBE` | `/usr/local/bin/...` | 開発時は偽物に差し替える |
-| `DENPA_COMMIT` | `dev` | 動いているコミット。**CI がイメージに焼き込む**。`dev` なら新しい版の知らせを出さない |
-| `DENPA_GITHUB_API` | `https://api.github.com/repos/danything/denpa` | 新しい版を見に行く先 (`releases/latest` と `compare`)。試験では偽物を指す |
+| `DENPA_VERSION` | `dev` | 動いている版。**リリースのイメージにだけ入る** (リリース時に main のイメージへ 1 層足す。`.github/release.Dockerfile`)。`dev` (develop・手元) なら新しい版の知らせを出さない |
+| `DENPA_GITHUB_API` | `https://api.github.com/repos/danything/denpa` | 新しい版を見に行く先 (`releases/latest`)。試験では偽物を指す |
 | `UPDATE_CHECK_INTERVAL` | 1時間 | 新しい版を見に行く間隔 (ms) |
 | `ENCODE_CONCURRENCY` | `1` | 録画エンコードの同時実行数 |
 | `HW_DEVICES` | `/dev/dri/renderD*` | GPU の口を探す形。当たった口を全部試し、QSV / VA-API が初期化できたもので焼く ([encode.md](encode.md)「GPU で焼く」) |
@@ -235,7 +235,7 @@ SQLite が拒むので、事実と状態が食い違いようがありません�
 | `/api/recordings/<id>/share` | 期限付きの再生リンクを作る (share.ts)。テレビへの飛ばしもこれを使う。**リンクの尻は `/file/<番組名>.mkv`** (生TS の名指しなら `.m2ts`) — テレビの VLC は URL の最後の区切りを見出しにするので (入れ物の title は見出しに効かない)、名前をここに乗せる。サーバはその段を読み捨てる (`file/[name]/+server.ts`) |
 | 画面の高さの採り方 | **単位で言い当てない。** `app.css` が `html, body` に高さを与え、土台も番組詳細の窓もそこから `%` で降りる (`min-h-full` / `md:h-full`)。`100vh` も `100dvh` も**実機の PWA (Android Chrome) で画面より 56px 大きく出た** — 56px は Chrome for Android のアドレスバーの高さそのもの。`%` なら JS も測り直しも要らず、**描く前から正しい**。`%` が届かないのは番組表の表だけ (畳まれる幅では途中の入れ物に高さが決まらない)。そこは `svh` — 3つの単位のうち**見えている範囲を超えない側**だから |
 | `?measure` (どの画面でも) | **その端末の高さを読む札** (`components/Measure.svelte`)。窓・枠・中身の高さと、`dvh`/`svh`/`lvh`/`vh` の実測、はみ出している要素を出す。縦のはみ出しは**端末でしか起きない**ことがあり (引っ込むアドレスバー、切り欠き)、自動運転のブラウザでは作れない。**PWA にはアドレスバーが無い**ので、設定画面にも入り切りがある (そちらは覚える。端末ごとで、サーバには置かない) |
-| ヘッダー (どの画面でも) | **新しい版が出ていれば札を出す** (`v1.8.0 が出ています`。押せば GitHub のリリース)。サーバが 1 時間に 1 度、GitHub の最新のリリースが動いているコミット (`DENPA_COMMIT`) より先かを compare API で見る (`server/update.ts`。版の札は焼き込まない — リリースはイメージを組み直さず名前を貼るだけなので、中身は自分が何版か知りようがない)。先にあっても、その間のコミットが denpa の中身 (`src` や `Dockerfile`) に触っていなければ出さない — リリースの札は印の書き戻し (`k3s/` だけ) のコミットに付くので。**リリースを消せば引っ込む** — 最新は消したあとの版になるので。閉じる口は置いていない (上げるか、消えるまで出ている) |
+| ヘッダー (どの画面でも) | **新しい版が出ていれば札を出す** (`v1.8.0 が出ています`。押せば GitHub のリリース)。サーバが 1 時間に 1 度、動いている版 (`DENPA_VERSION`。リリースのイメージにだけ入っている) と GitHub の最新のリリースを数で比べる (`server/update.ts`)。develop のイメージは版を持たないので出さない — main を追いかけている限りリリースより常に先。**リリースを消せば引っ込む** — 最新は消したあとの版になるので。閉じる口は置いていない (上げるか、消えるまで出ている) |
 | `/manifest.webmanifest` | PWA のマニフェスト。**来た名前で表示名が変わる**ので静的ファイルではない。認証を掛けていない口の1つ (ブラウザが資格情報を付けずに取りに来るため。他は `/login*`・`/logout`・`/api/health`。`auth.ts` の `OPEN_PATHS`) |
 
 ## チューナーエージェント (`agent/`)

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,6 +135,9 @@ JSON で持つ列 (ジャンル・音声の構成・ルールの対象チャン�
 CI が両方を焼いて `k3s/` の印を書き戻します。**main は直接 push できない**
 (必須チェック `check` で守ってある) ので、書き戻しは bot が PR を出して自分で
 マージします (手順と理由は `.github/bump-pr.sh`。release の Chart.yaml の書き戻しも同じ)。
+release はイメージを組み直さず、main で組んだものに版を 1 層足して (`.github/release.Dockerfile`
+の `ENV DENPA_VERSION`) `x.y.z` / `latest` の名前を付けます。動いている denpa はその版と GitHub の
+最新のリリースを数で比べ、新しい版があればヘッダーで知らせます (`src/lib/server/update.ts`)。
 
 `latest` が動くのはリリースを作ったときだけ (焼き直さず貼り替える) — タグの決め方と
 理由は [architecture.md](architecture.md#イメージのタグ)、出し方は `.github/image-tags.sh`。

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -169,11 +169,12 @@ export const config = {
     bmlDns: str('BML_DNS', '1.1.1.1,8.8.8.8'),
 
     /**
-     * 動いているコミット。**イメージを組むときに入る** (Dockerfile の `DENPA_COMMIT`)。
-     * 手元や試験では `dev` で、そのときは新しい版の知らせを出さない (update.ts)
+     * 動いている版 (`v1.8.1` の形)。**リリースのイメージにだけ入る** — リリースのとき、
+     * main で組んだイメージに 1 層足す (.github/release.Dockerfile)。main (develop) の
+     * イメージと手元・試験は `dev` で、そのときは新しい版の知らせを出さない (update.ts)
      */
-    commit: str('DENPA_COMMIT', 'dev'),
-    /** 新しい版を見に行く先。GitHub の API (`releases/latest` と `compare`)。試験では偽物を指す */
+    version: str('DENPA_VERSION', 'dev'),
+    /** 新しい版を見に行く先。GitHub の API (`releases/latest`)。試験では偽物を指す */
     githubApi: str('DENPA_GITHUB_API', 'https://api.github.com/repos/danything/denpa').replace(/\/+$/, ''),
     /** 新しい版を見に行く間隔 (ms)。認証なしの GitHub API は 1 時間に 60 回まで */
     updateCheckInterval: num('UPDATE_CHECK_INTERVAL', 60 * MIN),

--- a/src/lib/server/update.test.ts
+++ b/src/lib/server/update.test.ts
@@ -1,32 +1,18 @@
 import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import { config } from './config';
-import { checkForUpdate, DENPA_PATHS, updateAvailable } from './update';
+import { checkForUpdate, newer, parseVersion, updateAvailable } from './update';
 
-const original = { commit: config.commit, githubApi: config.githubApi };
+const original = { version: config.version, githubApi: config.githubApi };
 afterEach(() => {
     Object.assign(config, original);
 });
 
-type Status = 'ahead' | 'behind' | 'identical' | 'diverged';
-
-/**
- * GitHub の代わり。最新のリリースと、動いているコミットから見た前後を決めて渡す。
- * `release` が null なら「1 つも無い」(404)
- */
-function github(
-    release: Record<string, unknown> | null,
-    status: Status = 'ahead',
-    files: { filename: string }[] | undefined = [{ filename: 'src/lib/server/update.ts' }],
-) {
+/** GitHub の代わり。最新のリリースを決めて渡す。null なら「1 つも無い」(404) */
+function github(release: Record<string, unknown> | null) {
     const asked: string[] = [];
     const fetcher = async (url: string) => {
         asked.push(url);
-        if (url.endsWith('/releases/latest')) {
-            return release === null ? new Response('', { status: 404 }) : Response.json(release);
-        }
-        if (url.includes('/compare/'))
-            return Response.json(files === undefined ? { status } : { status, files });
-        return new Response('', { status: 500 });
+        return release === null ? new Response('', { status: 404 }) : Response.json(release);
     };
     return Object.assign(fetcher, { asked });
 }
@@ -37,92 +23,60 @@ const release = (tag: string, extra: Record<string, unknown> = {}) => ({
     ...extra,
 });
 
+describe('版の札', () => {
+    test('v 付きでも無しでも読む。試し版と dev は読めない', () => {
+        expect(parseVersion('v1.7.1')).toEqual([1, 7, 1]);
+        expect(parseVersion('1.10.0')).toEqual([1, 10, 0]);
+        expect(parseVersion('v2.0.0-rc1')).toBeNull();
+        expect(parseVersion('dev')).toBeNull();
+    });
+
+    test('数で比べる (文字の並びではない)', () => {
+        expect(newer([1, 10, 0], [1, 9, 9])).toBe(true);
+        expect(newer([1, 7, 1], [1, 7, 1])).toBe(false);
+        expect(newer([1, 7, 0], [1, 7, 1])).toBe(false);
+    });
+});
+
 describe('新しい版の知らせ', () => {
-    test('最新のリリースが動いているコミットより先なら出る。含んでいれば出ない', async () => {
-        config.commit = 'abc1234';
-        const gh = github(release('v1.8.0'), 'ahead');
+    test('向こうが新しければ出る。同じ・古ければ出ない', async () => {
+        config.version = 'v1.7.1';
+        const gh = github(release('v1.8.0'));
         expect(await checkForUpdate(gh)).toEqual({
             version: 'v1.8.0',
             url: 'https://github.com/danything/denpa/releases/tag/v1.8.0',
         });
         expect(updateAvailable()?.version).toBe('v1.8.0');
-        // 訊き方: 自分のコミット...リリースの札
-        expect(gh.asked[1]).toContain('/compare/abc1234...v1.8.0');
-
-        // main のほうが先 (リリースの後の main を動かしている) / 同じコミット
-        expect(await checkForUpdate(github(release('v1.8.0'), 'behind'))).toBeNull();
-        expect(await checkForUpdate(github(release('v1.8.0'), 'identical'))).toBeNull();
-        // 枝分かれ (別の枝から出したリリース) は数えない
-        expect(await checkForUpdate(github(release('v1.8.0'), 'diverged'))).toBeNull();
-    });
-
-    /*
-     * リリースの札は「印の書き戻し」(k3s/ だけ) のコミットに付き、イメージはその 1 つ前で
-     * 組まれる。先にあっても denpa の中身に触っていなければ、動いているのはそのリリース
-     */
-    test('先にあっても、denpa の中身に触っていなければ出ない', async () => {
-        config.commit = 'abc1234';
-        expect(
-            await checkForUpdate(github(release('v1.8.0'), 'ahead', [{ filename: 'k3s/application.yaml' }])),
-        ).toBeNull();
-        expect(
-            await checkForUpdate(
-                github(release('v1.8.0'), 'ahead', [
-                    { filename: 'charts/denpa/Chart.yaml' },
-                    { filename: 'docs/app.md' },
-                ]),
-            ),
-        ).toBeNull();
-        // 中身に触っていれば出る (Dockerfile そのもの、src の下)
-        expect(
-            (await checkForUpdate(github(release('v1.8.0'), 'ahead', [{ filename: 'Dockerfile' }])))?.version,
-        ).toBe('v1.8.0');
-        expect(
-            (
-                await checkForUpdate(
-                    github(release('v1.8.0'), 'ahead', [{ filename: 'k3s/x' }, { filename: 'src/a.ts' }]),
-                )
-            )?.version,
-        ).toBe('v1.8.0');
-        // files が無い答えと、切れている答え (300 個) は触ったことにする
-        expect((await checkForUpdate(github(release('v1.8.0'), 'ahead', undefined)))?.version).toBe('v1.8.0');
-        const many = Array.from({ length: 300 }, (_, i) => ({ filename: `k3s/${i}` }));
-        expect((await checkForUpdate(github(release('v1.8.0'), 'ahead', many)))?.version).toBe('v1.8.0');
-    });
-
-    test('denpa の中身のパスは .github/image-tags.sh と同じ', async () => {
-        const script = await Bun.file('.github/image-tags.sh').text();
-        const listed = /^denpa_paths="([^"]+)"/m.exec(script)?.[1]?.split(/\s+/);
-        expect(listed).toEqual(DENPA_PATHS);
+        expect(gh.asked[0]).toBe(`${config.githubApi}/releases/latest`);
+        expect(await checkForUpdate(github(release('v1.7.1')))).toBeNull();
+        expect(await checkForUpdate(github(release('v1.7.0')))).toBeNull();
     });
 
     // リリースを消すと「最新」は 1 つ前になる。そこで知らせが引っ込む
     test('リリースが消えれば引っ込む。1 つも無ければ (404) も同じ', async () => {
-        config.commit = 'abc1234';
-        await checkForUpdate(github(release('v1.8.0'), 'ahead'));
+        config.version = 'v1.7.1';
+        await checkForUpdate(github(release('v1.8.0')));
         expect(updateAvailable()).not.toBeNull();
-        expect(await checkForUpdate(github(release('v1.7.1'), 'behind'))).toBeNull();
+        expect(await checkForUpdate(github(release('v1.7.1')))).toBeNull();
 
-        await checkForUpdate(github(release('v1.8.0'), 'ahead'));
+        await checkForUpdate(github(release('v1.8.0')));
         expect(await checkForUpdate(github(null))).toBeNull();
     });
 
     test('dev では見に行かない。試し版・下書きは数えない', async () => {
-        config.commit = 'dev';
+        config.version = 'dev';
         const gh = github(release('v9.9.9'));
         expect(await checkForUpdate(gh)).toBeNull();
         expect(gh.asked).toHaveLength(0);
 
-        config.commit = 'abc1234';
-        const draft = github(release('v2.0.0', { draft: true }));
-        expect(await checkForUpdate(draft)).toBeNull();
+        config.version = 'v1.7.1';
         expect(await checkForUpdate(github(release('v2.0.0', { prerelease: true })))).toBeNull();
-        // 下書きなら compare まで訊かない
-        expect(draft.asked).toHaveLength(1);
+        expect(await checkForUpdate(github(release('v2.0.0', { draft: true })))).toBeNull();
+        expect(await checkForUpdate(github(release('v2.0.0-rc1')))).toBeNull();
     });
 
     test('繋がらないことは 1 回だけ言い、いちど繋がれば (404 でも) また言う', async () => {
-        config.commit = 'abc1234';
+        config.version = 'v1.7.1';
         const warn = spyOn(console, 'warn').mockImplementation(() => {});
         try {
             const failing = async () => {
@@ -140,14 +94,14 @@ describe('新しい版の知らせ', () => {
     });
 
     test('繋がらない・形が違うときは、前に分かっていたことを持つ', async () => {
-        config.commit = 'abc1234';
+        config.version = 'v1.7.1';
         await checkForUpdate(github(release('v1.8.0')));
         const failing = async () => {
             throw new Error('繋がらない');
         };
         expect((await checkForUpdate(failing))?.version).toBe('v1.8.0');
         expect((await checkForUpdate(github({ tag: 'v1.9.0' })))?.version).toBe('v1.8.0');
-        const odd = async () => Response.json({ status: 'sideways' });
+        const odd = async () => new Response('', { status: 500 });
         expect((await checkForUpdate(odd))?.version).toBe('v1.8.0');
     });
 });

--- a/src/lib/server/update.ts
+++ b/src/lib/server/update.ts
@@ -1,23 +1,19 @@
 /**
- * 新しい版が出ているか。**GitHub のリリースが、動いているコミットより先か**を見る。
+ * 新しい版が出ているか。**動いている版と GitHub の最新のリリースを数で比べる。**
  *
- * 動いているのはコミット (`config.commit`。イメージを組むときに入る)。GitHub の
- * 「最新のリリース」の札を取り、compare API でそのコミットとの前後を訊く
- * (`/compare/<コミット>...<札>`)。**リリースのほうが先 (`ahead`) で、その先のコミットが
- * denpa の中身 (`DENPA_PATHS`) に触っていれば知らせる。**
- *
- * 版の札を焼き込んで数で比べる手は取らない — リリースはイメージを組み直さず
- * main のものに名前を貼るだけなので (release.yml)、v1.8.0 のイメージの中身は
- * 「v1.7.1 の後の main」でしかなく、自分が v1.8.0 だと知りようがない。
- * コミットなら組んだときに必ず分かり、前後は GitHub が知っている。
+ * 動いている版 (`config.version`) はリリースのイメージにだけ入っている — リリースの
+ * とき、main で組んだイメージに 1 層足す (.github/release.Dockerfile)。GitHub の
+ * 「最新のリリース」の札を 1 時間に 1 度取り、向こうが新しければヘッダーに出す
+ * (`+layout.svelte`)。
  *
  * **リリースを消せば知らせも消える** — 「最新」は消したあとの版になるので、次に
- * 見比べたときに引っ込む。手元や試験の `dev` では何も出さない。繋がらないときは
- * **前に分かっていたことをそのまま持つ** (消すと点滅する)。1 時間に 2 回の呼び出し
- * (認証なしの GitHub API は 60 回/時)
+ * 見比べたときに引っ込む。main (develop) のイメージと手元・試験は `dev` で、何も
+ * 出さない — main を追いかけている限りリリースより常に先。読めない札 (試し版の
+ * `v2.0.0-rc1` など) も同じ。繋がらないときは**前に分かっていたことをそのまま持つ**
+ * (消すと点滅する)
  */
 
-import { array, boolean, type Infer, literal, object, optional, read, string } from '../shape';
+import { boolean, type Infer, object, optional, read, string } from '../shape';
 import { config } from './config';
 
 const RELEASE = object({
@@ -27,47 +23,6 @@ const RELEASE = object({
     prerelease: optional(boolean),
 });
 type Release = Infer<typeof RELEASE>;
-
-/**
- * compare API の答えのうち見るもの。`base...head` で head が base より先なら `ahead`。
- * `files` は先にあるコミットで変わったファイル (300 個まで。それ以上は切れる)
- */
-const COMPARISON = object({
-    status: literal('ahead', 'behind', 'identical', 'diverged'),
-    files: optional(array(object({ filename: string }))),
-});
-
-/**
- * **denpa のイメージの中身になるパス。** `.github/image-tags.sh` の `denpa_paths` と
- * 同じもの (試験で突き合わせている)。
- *
- * リリースの札は「印の書き戻し」のコミット (`k3s/` だけを触る) に付き、イメージは
- * その 1 つ前で組まれる。コミットの前後だけで見ると、そのリリースそのものを
- * 動かしていても「1 つ先」になって札が出る。**先にあるコミットがここに触って
- * いなければ、動いているものは中身としてそのリリース** — 知らせない
- */
-export const DENPA_PATHS = [
-    'Dockerfile',
-    'src',
-    'static',
-    'package.json',
-    'bun.lock',
-    'svelte.config.ts',
-    'vite.config.ts',
-    'server.js',
-    'patches',
-];
-
-/** compare API が 1 度に返すファイルの上限。ここまで来たら切れているとみなし、触ったことにする */
-const FILES_LIMIT = 300;
-
-/** 変わったファイルに denpa の中身が混じっているか。切れていれば混じっていることにする */
-export function touchesDenpa(files: { filename: string }[]): boolean {
-    if (files.length >= FILES_LIMIT) return true;
-    return files.some(({ filename }) =>
-        DENPA_PATHS.some((path) => filename === path || filename.startsWith(`${path}/`)),
-    );
-}
 
 export interface Available {
     /** `v1.8.0` の形。そのまま画面に出す */
@@ -88,23 +43,37 @@ export function updateAvailable(): Available | null {
     return available;
 }
 
+/** `v1.7.1` → `[1, 7, 1]`。読めなければ null (`dev`、試し版) */
+export function parseVersion(tag: string): [number, number, number] | null {
+    const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(tag.trim());
+    if (match === null) return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/** a が b より新しいか */
+export function newer(a: [number, number, number], b: [number, number, number]): boolean {
+    for (let i = 0; i < 3; i++) {
+        if (a[i] !== b[i]) return a[i]! > b[i]!;
+    }
+    return false;
+}
+
 /**
  * 見比べる。**外に出る呼び出しはここだけ。** 試験は `fetcher` を差し替える
  *
  * 404 は「リリースが 1 つも無い」なので知らせ無し。それ以外の失敗は前の結果を持つ
  */
 export async function checkForUpdate(fetcher: Fetcher = fetch): Promise<Available | null> {
-    if (config.commit === 'dev') {
+    const current = parseVersion(config.version);
+    if (current === null) {
         available = null;
         return available;
     }
-    const get = async (path: string): Promise<Response> =>
-        fetcher(`${config.githubApi}${path}`, {
+    try {
+        const res = await fetcher(`${config.githubApi}/releases/latest`, {
             headers: { accept: 'application/vnd.github+json', 'user-agent': 'denpa' },
             signal: AbortSignal.timeout(10_000),
         });
-    try {
-        const res = await get('/releases/latest');
         if (res.status === 404) {
             // 繋がった (リリースが 1 つも無いだけ)。次に繋がらなくなったら、また言う
             available = null;
@@ -113,18 +82,14 @@ export async function checkForUpdate(fetcher: Fetcher = fetch): Promise<Availabl
         }
         if (!res.ok) throw new Error(`releases/latest が ${res.status} を返しました`);
         const release: Release = read(RELEASE, await res.json(), 'GitHub のリリース');
-
-        let ahead = false;
-        if (!(release.draft ?? false) && !(release.prerelease ?? false)) {
-            const compared = await get(
-                `/compare/${encodeURIComponent(config.commit)}...${encodeURIComponent(release.tag_name)}`,
-            );
-            if (!compared.ok) throw new Error(`compare が ${compared.status} を返しました`);
-            const comparison = read(COMPARISON, await compared.json(), 'GitHub の compare');
-            // files が無い答え (古い API・偽物) は、先なら触ったことにする
-            ahead = comparison.status === 'ahead' && touchesDenpa(comparison.files ?? [{ filename: 'src' }]);
-        }
-        available = ahead ? { version: release.tag_name, url: release.html_url } : null;
+        const latest = parseVersion(release.tag_name);
+        available =
+            latest !== null &&
+            !(release.draft ?? false) &&
+            !(release.prerelease ?? false) &&
+            newer(latest, current)
+                ? { version: release.tag_name, url: release.html_url }
+                : null;
         warned = false;
     } catch (error) {
         if (!warned) {

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -11,13 +11,13 @@ import { updateAvailable } from '$lib/server/update';
  *
  * 録画の本数も返す。入れ替えていいかどうかを外から見たいことがあるため
  * (待つこと自体はアプリ側でやっている。runtime.ts の drain)。
- * 動いているコミットも返す (`DENPA_COMMIT`。手元では `dev`) — 何が動いているかを外から確かめるため
+ * 版も返す (`DENPA_VERSION`。リリースのイメージだけが持つ。手元と develop は `dev`) — 何が動いているかを外から確かめるため
  */
 export function GET() {
     const row = orm().select({ n: count() }).from(services).get();
     return json({
         ok: true,
-        commit: config.commit,
+        version: config.version,
         // 新しい版が出ていれば、その札と場所 (update.ts)。無ければ null
         update: updateAvailable(),
         services: row?.n ?? 0,

--- a/tests/e2e/01-dashboard.spec.ts
+++ b/tests/e2e/01-dashboard.spec.ts
@@ -228,7 +228,7 @@ test.describe('ダッシュボードと画面遷移', () => {
      * **新しい版が出ていたら、ヘッダーで知らせる。** サーバが GitHub の最新の
      * リリースを見比べる (`server/update.ts`。ここでは偽通知先が GitHub の代わり)。
      * 出ること・押せばリリースのページなこと・**リリースが消えれば引っ込むこと**を見る。
-     * 動いているコミットは e2e0000 (tests/stack.ts)、見比べは 1 秒おき
+     * 動いている版は v1.0.0 (tests/stack.ts)、見比べは 1 秒おき
      */
     test('新しい版が出ていればヘッダーに出て、リリースが消えれば引っ込む', async ({
         page,
@@ -242,13 +242,12 @@ test.describe('ダッシュボードと画面遷移', () => {
                 body: JSON.stringify(body),
             });
         const badge = page.getByTestId('update-available');
-        // 動いているコミットは環境変数から (tests/stack.ts)。外からも読める
-        expect((await (await request.get('/api/health')).json()).commit).toBe('e2e0000');
+        // 動いている版は環境変数から (tests/stack.ts)。外からも読める
+        expect((await (await request.get('/api/health')).json()).version).toBe('v1.0.0');
         try {
             await release({
                 tag_name: 'v9.9.9',
                 html_url: 'https://github.com/danything/denpa/releases/tag/v9.9.9',
-                status: 'ahead',
             });
             // サーバが気付く (1 秒おき)。外からは /api/health で見える
             await expect
@@ -260,11 +259,10 @@ test.describe('ダッシュボードと画面遷移', () => {
             await expect(badge).toContainText('v9.9.9');
             await expect(badge).toHaveAttribute('href', /releases\/tag\/v9\.9\.9$/);
 
-            // 最新が自分より前の版になった (新しいほうのリリースを消した) → 引っ込む
+            // 最新が古い版になった (新しいほうのリリースを消した) → 引っ込む
             await release({
                 tag_name: 'v0.9.0',
                 html_url: 'https://github.com/danything/denpa/releases/tag/v0.9.0',
-                status: 'behind',
             });
             await expect
                 .poll(async () => (await (await request.get('/api/health')).json()).update, {

--- a/tests/fake/webhook.ts
+++ b/tests/fake/webhook.ts
@@ -27,12 +27,6 @@ Bun.serve({
         if (url.pathname === '/releases/latest') {
             return release === null ? new Response('not found', { status: 404 }) : json(release);
         }
-        // 動いているコミットから見た前後。置いたリリースの `status` をそのまま返す (既定は先)。
-        // 変わったファイルは denpa の中身 (触っていないと知らせが出ない)
-        if (url.pathname.startsWith('/compare/')) {
-            const status = (release as { status?: string } | null)?.status ?? 'ahead';
-            return json({ status, files: [{ filename: 'src/app.html' }] });
-        }
         if (url.pathname === '/__control/release' && request.method === 'POST') {
             release = await request.json();
             return json({ ok: true });

--- a/tests/stack.ts
+++ b/tests/stack.ts
@@ -194,9 +194,9 @@ async function boot(index: number): Promise<{ stack: Stack; shutdown: () => Prom
             FAKE_FFMPEG_ENCODE_ARGS_FILE: stack.encodeArgsFile,
             /*
              * 新しい版の知らせ。GitHub の代わりに偽通知先が「最新のリリース」を返す
-             * (既定は無し) と、動いているコミットから見た前後 (compare)
+             * (既定は無し)。動いている版は古めにして、置いたリリースが必ず新しく見えるように
              */
-            DENPA_COMMIT: 'e2e0000',
+            DENPA_VERSION: 'v1.0.0',
             DENPA_GITHUB_API: stack.webhookUrl,
             UPDATE_CHECK_INTERVAL: '1000',
             // 定期処理は止め、テストからボタン/APIで明示的に走らせる(タイミング依存を避ける)


### PR DESCRIPTION
## 何を

新しい版の知らせの決め方を、**リリースのイメージに版を 1 層足して数で比べる**形にしました (#57 / #60 の compare API とパス判定をやめる)。

## どう変えたか

- **`release.yml`**: denpa のイメージは `imagetools create` で名前を貼る代わりに、main で組んだ `sha-…` のイメージを土台に `ENV DENPA_VERSION=vX.Y.Z` を 1 層足したものを `x.y.z` / `x.y` / `latest` として push します (`.github/release.Dockerfile`)。**組み直しません** — 中身の層は main のイメージと同じで、増えるのはメタデータ 1 枚。数秒です。エージェントはこれまでどおり名前を貼るだけ
- **`update.ts`**: 動いている版 (`DENPA_VERSION`) と GitHub の最新のリリースの札を**数で比べる**だけ。呼び出しは 1 時間に 1 回。`dev` (develop・手元) では見に行かない、試し版・下書きは数えない、リリースを消せば引っ込む、繋がらなければ前の結果を持つ、は同じ
- **消えたもの**: compare API、`DENPA_PATHS` と `image-tags.sh` との突き合わせ試験、`DENPA_COMMIT`。build-and-deploy の build-arg も無くなり、main のイメージは `dev` のまま
- `/api/health` は `version` に戻ります (リリースのイメージだけ `v1.8.2` の形。develop は `dev`)

## 誰に出るか

- **リリースのイメージ** (`1.8.x` / `latest`) を動かしている人: 新しいリリースが出たら札が出る。そのリリースそのものを動かしていれば出ない (版が同じなので)
- **develop** (main を追いかける構成。自分の環境): 出ない。main を追いかけている限りリリースより常に先で、知らせが要る場面が無い

## 試験

- 単体 (`update.test.ts`, 7 本): 版の読みと比べ方、新しい・同じ・古い、消えた・404、dev と試し版・下書き、繋がらない警告は 1 回、形が違えば前のまま
- e2e: 偽 GitHub は `releases/latest` だけ
- lint / 型チェック 0 エラー、単体 811 本、e2e 全体
- `release.yml` の変更は次のリリース (v1.8.2) で本番の GHCR に対して確かめます

🤖 Generated with [Claude Code](https://claude.com/claude-code)
