### PR TITLE
chore: Infisical の projectSlug を doany-cluster にする

### DIFF
--- a/deploy/oidc-secret.yaml
+++ b/deploy/oidc-secret.yaml
@@ -17,7 +17,7 @@ spec:
         name: infisical-auth
         namespace: infisical
       secretsScope:
-        projectSlug: doany-cluster
+        projectSlug: doany
         envSlug: prod
         secretsPath: /denpa/denpa-oidc
         recursive: false

--- a/deploy/oidc-secret.yaml
+++ b/deploy/oidc-secret.yaml
@@ -17,7 +17,7 @@ spec:
         name: infisical-auth
         namespace: infisical
       secretsScope:
-        projectSlug: doany
+        projectSlug: doa
         envSlug: prod
         secretsPath: /denpa/denpa-oidc
         recursive: false

--- a/deploy/oidc-secret.yaml
+++ b/deploy/oidc-secret.yaml
@@ -17,7 +17,7 @@ spec:
         name: infisical-auth
         namespace: infisical
       secretsScope:
-        projectSlug: k3s-cluster
+        projectSlug: doany-cluster
         envSlug: prod
         secretsPath: /denpa/denpa-oidc
         recursive: false


### PR DESCRIPTION
クラスタが k3s でなくなるので、Infisical のプロジェクト slug を `k3s-cluster` → `doany-cluster` に変える。

**マージ順**: 先に Infisical の UI で slug を変更し、そのあとで各リポジトリの PR をまとめてマージする。逆順だと operator の同期が失敗する(ただし既存の Secret は `creationPolicy: Orphan` なので消えず、Pod は動き続ける)。

関連 PR は 7 リポジトリ分(gitops / blog / denpa / lgtm / tamasagashi / worklog-cloud / xool)。gitops の `bootstrap/` にある CR は Argo CD の同期対象外なので、マージ後に手で apply する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv