### PR TITLE
feat(chart): Gateway API の HTTPRoute に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ docker compose up -d
 helm install denpa oci://ghcr.io/danything/charts/denpa \
   --namespace denpa --create-namespace \
   --set denpa.trustedNetworks=192.168.0.0/16 \
-  --set ingress.enabled=true --set 'ingress.hosts[0]=denpa.example.home'
+  --set httpRoute.enabled=true \
+  --set 'httpRoute.parentRefs[0].name=my-gateway' \
+  --set 'httpRoute.parentRefs[0].namespace=gateway-system' \
+  --set 'httpRoute.hostnames[0]=denpa.example.home'
 ```
 
 チューナーの刺さった機械にはエージェントだけ置き、本体は別の所 (別ノードや

--- a/charts/denpa/templates/httproute.yaml
+++ b/charts/denpa/templates/httproute.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.httpRoute.enabled }}
+# Gateway API の HTTPRoute。**認証は denpa 自身がやる** (docs/auth.md) ので、前段は名前を届けるだけ。
+# 証明書は Gateway 側のリスナーが持つので、ここでは指定しない (Ingress の tls に相当するものが無い)。
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: denpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "denpa.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- $hosts := .Values.httpRoute.hostnames | default .Values.ingress.hosts }}
+  {{- with $hosts }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: denpa
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/denpa/values.yaml
+++ b/charts/denpa/values.yaml
@@ -130,7 +130,22 @@ service:
   publishNotReadyAddresses: true
 
 # 入口。**denpa 自身が認証する**ので、前段は名前を届けるだけでよい。
-# 標準の Ingress か、Traefik の IngressRoute のどちらか (両方は要らない)
+# Gateway API の HTTPRoute・標準の Ingress・Traefik の IngressRoute のどれか 1 つ
+# (複数を同時に有効にしても壊れはしないが、要らない)。
+# **新しく組むなら httpRoute。** Ingress API は凍結済みで、ingress-nginx も 2026-03 に retire した。
+# このリポジトリ自身の本番は httpRoute (Cilium Gateway)。
+httpRoute:
+  enabled: false
+  # **付け先の Gateway。省略できない** (HTTPRoute は自分では待ち受けを持たない)。
+  # sectionName はリスナー名。ホスト名の段数ごとにリスナーが分かれている構成では、
+  # 名前ごとに parentRef を分ける (例: *.example.com と *.lan.example.com)
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # 空なら下の ingress.hosts をそのまま使う (両方書く必要はない)
+  hostnames: []
+  annotations: {}
 ingress:
   enabled: false
   hosts: []

--- a/deploy/application.yaml
+++ b/deploy/application.yaml
@@ -54,7 +54,7 @@ spec:
           encodeConcurrency: 2
           # LAN から来たときだけ何も聞かずに通す (docs/auth.md)
           trustedNetworks: 10.10.0.0/16
-          # Traefik の後ろに居るので、接続元は x-forwarded-for から読む
+          # Gateway (Envoy) の後ろに居るので、接続元は x-forwarded-for から読む
           addressHeader: x-forwarded-for
           # 同じ denpa を2つの名前で出しているので、ホーム画面の名前を分ける
           pwaNames: dp.doany.io=denpa,dp.l.doany.io=denpa 宅内
@@ -64,16 +64,21 @@ spec:
         persistence:
           storageClassName: local-path-retain
 
-        ingress:
-          hosts:
+        # Cilium Gateway (danything/gitops の bootstrap/gateway/) に付ける。
+        # dp.doany.io は `*.doany.io` の、dp.l.doany.io は `*.l.doany.io` の
+        # リスナーに載るので、parentRef を 2 つに分ける (段数ごとに証明書が違うため)
+        httpRoute:
+          enabled: true
+          parentRefs:
+            - name: doany
+              namespace: kube-system
+              sectionName: https
+            - name: doany
+              namespace: kube-system
+              sectionName: https-lan
+          hostnames:
             - dp.doany.io
             - dp.l.doany.io
-        traefik:
-          enabled: true
-          entryPoints:
-            - websecure
-          certResolver: mydnschallenge
-          nativeLB: true
   syncPolicy:
     automated:
       prune: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ TSは追記で開いていて、次の起動で `recoverOrphanedRecordings` が�
    いちばん最後で、こちらはその手前 (`hooks.server.ts` はアプリの読み込みで走る)
    なので、**最初の引き取りでは外すものがまだ無い**。そのまま置くと両方が
    登録された状態になり、プロセスは生きたまま**ポートだけ閉じます** — 実機で
-   `/proc/net/tcp` に listen が1つも無く、Traefik が「no available server」を
+   `/proc/net/tcp` に listen が1つも無く、前段が「no available server」を
    返しているのに、番組表は集まり続けている状態を確認しました。
    `setImmediate` でもう一度引き取り直します。
 
@@ -198,12 +198,13 @@ PreSync フックに置いています (`denpa-prepull`、中身は `/bin/true`)
 共通アドオンは別の(プライベートな) bootstrap リポジトリ側です。適用前に以下が要ります。
 
 - **StorageClass `local-path-retain`** — `reclaimPolicy: Retain` の local-path
-- **Traefik** — `mydnschallenge` certResolver (Cloudflare DNS-01)。forward-auth を
-  外したので、名前空間をまたぐ参照はもうありません
+- **Gateway API の Gateway** — chart の `httpRoute.parentRefs` が指す先。証明書は
+  Gateway 側のリスナーが持ちます (このクラスタでは cert-manager が Cloudflare DNS-01 で発行)。
+  forward-auth を外したので、名前空間をまたぐ参照はもうありません
 - **ArgoCD** — push時に webhook が自動登録される運用。Application 自体は
   [deploy/application.yaml](../deploy/application.yaml) に置いてあり、bootstrap の
   ApplicationSet が `deploy/argocd.yaml` を見て拾います
-- **DNS** — `dp.doany.io` が Traefik の外部IPを指すこと。
+- **DNS** — `dp.doany.io` が Gateway の外部IPを指すこと。
   LAN 用の `dp.l.doany.io` は `*.l.doany.io` の書き換えで内側のIPへ
 - **チューナードライバ** — エージェントは `privileged: true` かつ `/dev/bus`・`/dev/dvb` を
   hostPath でマウントするので、ノード側にドライバが読み込まれていること

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -151,12 +151,11 @@ TRUSTED_NETWORKS=0.0.0.0/0
 ```
 
 **見るのは住所だけです。どの名前で来たかは問いません** — LAN から外向きの
-`dp.doany.io` を開いても、そのまま通ります。前段 (Traefik の IngressRoute、
-chart の `traefik.enabled`) は2つの名前を同じ Rule で denpa に届けるだけで、
-名前ごとに何かを分けてはいません。LAN 用の名前 `dp.l.doany.io` が家の中でだけ
+`dp.doany.io` を開いても、そのまま通ります。前段 (chart の `httpRoute`) は2つの名前を
+同じ HTTPRoute で denpa に届けるだけで、名前ごとに何かを分けてはいません。LAN 用の名前 `dp.l.doany.io` が家の中でだけ
 引けるのは DNS の側の話です ([player.md](player.md))。
 
-> **前段 (Traefik など) が居るなら `ADDRESS_HEADER=x-forwarded-for` を一緒に渡すこと。**
+> **前段 (Gateway やリバースプロキシ) が居るなら `ADDRESS_HEADER=x-forwarded-for` を一緒に渡すこと。**
 > 渡さないと接続元が前段の住所になり、住所の側が誰にも当たりません (=全員が認証を
 > 求められます)。逆に、denpa へ直に届く経路があるとヘッダを詐称できます — Pod が
 > Service 経由でしか触れないことが前提です。前段が居ない (ブラウザが直に denpa へ
@@ -237,10 +236,11 @@ denpa は Secret を環境変数で読むので、値を変えたら Pod を入�
 
 ### 前段の forward-auth は外しました
 
-IngressRoute から `forward-auth` と `forward-auth-errors` (oauth2-proxy) を
-落としてあります (いまは chart の `charts/denpa/templates/ingress.yaml`)。denpa が自分でログインさせるので、前段に置く理由がなくなりました。
+前段のルートから `forward-auth` と `forward-auth-errors` (oauth2-proxy) を
+落としてあります (いまは chart の `charts/denpa/templates/httproute.yaml`)。
+denpa が自分でログインさせるので、前段に置く理由がなくなりました。
 
-**順番が大事です。** 「denpa 側を設定 → **実機で入れることを確かめる** → ingress から
+**順番が大事です。** 「denpa 側を設定 → **実機で入れることを確かめる** → 前段から
 外す」。先に外すと、OIDC の設定を間違えていたときに*誰も入れない*ではなく
 **誰でも入れる**状態になります。
 

--- a/docs/player.md
+++ b/docs/player.md
@@ -71,7 +71,7 @@
 名前を LAN 内のアドレスに向ければ**、公開しないまま本物の証明書が使えます
 (DNS-01 なので外から繋がる必要がありません)。
 
-IngressRoute (chart の `ingress.hosts`) に
+HTTPRoute (chart の `httpRoute.hostnames`) に
 その名前を足してあり、**https://dp.l.doany.io** です。名前は家の中でだけ引け、
 denpa はそのネットワークから来た人には何も聞きません (`TRUSTED_NETWORKS`、[auth.md](auth.md))。
 プレイヤー (テレビの VLC) が録画を取りに来るのも同じ口です。


### PR DESCRIPTION
クラスタを Cilium Gateway + Gateway API に移して Traefik を消した結果、**denpa の経路だけが消えていました**。
denpa の公開は gitops 側の `Ingress` ではなく chart の `IngressRoute` で組んでいたので、Traefik の CRD ごと消えて `dp.doany.io` が 404 になっていました。

## chart
- `templates/httproute.yaml` を追加。`httpRoute.enabled` で有効になります
- `httpRoute.parentRefs` は省略不可(HTTPRoute は自分では待ち受けを持たない)
- `httpRoute.hostnames` が空なら `ingress.hosts` をそのまま使います
- **`ingress.enabled` と `traefik.enabled` は残します。** chart は外にも配っていて、Traefik や標準 Ingress のクラスタでもそのまま使えるほうがよいため

## 本番(`deploy/application.yaml`)
`traefik.enabled` から `httpRoute` へ。`dp.doany.io` は `*.doany.io` の、`dp.l.doany.io` は `*.l.doany.io` のリスナーに載るので `parentRefs` を 2 つに分けています(段数ごとに証明書が違うため)。
`*.l.doany.io` のリスナーと証明書は danything/gitops 側で足しました。

docs も Traefik 前提の記述を Gateway API に合わせています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv