### PR TITLE
fix(chart): HTTPRoute の既定値を明示し、parentRefs 未指定を弾く

### DIFF
--- a/charts/denpa/templates/httproute.yaml
+++ b/charts/denpa/templates/httproute.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
+{{- if not .Values.httpRoute.parentRefs }}
+{{- fail "httpRoute.enabled のときは httpRoute.parentRefs が要ります (HTTPRoute は自分では待ち受けを持たないため)" }}
+{{- end }}
 # Gateway API の HTTPRoute。**認証は denpa 自身がやる** (docs/auth.md) ので、前段は名前を届けるだけ。
 # 証明書は Gateway 側のリスナーが持つので、ここでは指定しない (Ingress の tls に相当するものが無い)。
 apiVersion: gateway.networking.k8s.io/v1
@@ -13,8 +16,24 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  # group / kind / weight は API サーバが既定値を入れる。**明示的に書いておく** —
+  # 省くと「書いたもの」と「クラスタにあるもの」が食い違い、ArgoCD が
+  # ServerSideApply のとき永久に OutOfSync のままになる
   parentRefs:
-    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - group: {{ .group | default "gateway.networking.k8s.io" }}
+      kind: {{ .kind | default "Gateway" }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+    {{- end }}
   {{- $hosts := .Values.httpRoute.hostnames | default .Values.ingress.hosts }}
   {{- with $hosts }}
   hostnames:
@@ -26,6 +45,9 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: denpa
+        - group: ""
+          kind: Service
+          name: denpa
           port: {{ .Values.service.port }}
+          weight: 1
 {{- end }}


### PR DESCRIPTION
#70 のあと、`denpa-chart` の Application が同期に成功しているのに **OutOfSync のまま**になっていました。

差分は API サーバの既定値だけでした:

```
   parentRefs:
-  - name: doany
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: doany
   backendRefs:
-    - name: denpa
+    - group: ''
+      kind: Service
+      name: denpa
       port: 3000
+      weight: 1
```

ArgoCD は `ServerSideApply=true` のときこれを吸収しないので、テンプレート側で明示的に書きます。

あわせて `httpRoute.enabled=true` で `parentRefs` が空のときは `fail` で止めます。Helm の `required` は空リストには効かない(nil と空文字列にしか効かない)ので、黙って `parentRefs: []` の HTTPRoute ができていました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv