### PR TITLE
chart: PVC を守るかどうかを persistence.protectFromPruning にする

### DIFF
--- a/charts/denpa-agent/templates/pvc.yaml
+++ b/charts/denpa-agent/templates/pvc.yaml
@@ -1,5 +1,6 @@
 {{- if not .Values.persistence.config.existingClaim }}
-# エージェントの設定 (tuners.json / channels.json)。ArgoCD に消させない
+# エージェントの設定 (tuners.json / channels.json)。既定では ArgoCD に消させない
+# (persistence.protectFromPruning)
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,7 +9,9 @@ metadata:
   labels:
     {{- include "denpa-agent.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.persistence.protectFromPruning }}
     argocd.argoproj.io/sync-options: Prune=false,Delete=false
+    {{- end }}
     helm.sh/resource-policy: keep
 spec:
   accessModes:
@@ -31,7 +34,9 @@ metadata:
   labels:
     {{- include "denpa-agent.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.persistence.protectFromPruning }}
     argocd.argoproj.io/sync-options: Prune=false,Delete=false
+    {{- end }}
     helm.sh/resource-policy: keep
 spec:
   accessModes:

--- a/charts/denpa-agent/values.yaml
+++ b/charts/denpa-agent/values.yaml
@@ -34,6 +34,11 @@ affinity: {}
 
 persistence:
   storageClassName: ""
+  # **PVC を ArgoCD に消させない** (Prune=false,Delete=false)。既定は true で、
+  # true の間は chart から PVC が消えても・Application ごと消しても ArgoCD は触らない。
+  # **false にすると「git で消したものは実際に消える」** — マニフェストから外れた
+  # 時点でボリュームごと消えるので、バックアップを用意してからにすること
+  protectFromPruning: true
   # エージェントの設定 (tuners.json / channels.json)
   config:
     size: 128Mi

--- a/charts/denpa/templates/pvc.yaml
+++ b/charts/denpa/templates/pvc.yaml
@@ -1,5 +1,6 @@
 {{- /*
-置き場。**ArgoCD に消させない** (Prune=false,Delete=false)。ここが消えると録画が消える。
+置き場。既定では **ArgoCD に消させない** (Prune=false,Delete=false)。ここが消えると録画が消える。
+外すかどうかは persistence.protectFromPruning (values.yaml に理由つきで書いてある)。
 existingClaim を渡したものは作らない
 */ -}}
 {{- $root := . -}}
@@ -21,7 +22,9 @@ metadata:
   labels:
     {{- include "denpa.labels" $root | nindent 4 }}
   annotations:
+    {{- if $root.Values.persistence.protectFromPruning }}
     argocd.argoproj.io/sync-options: Prune=false,Delete=false
+    {{- end }}
     helm.sh/resource-policy: keep
 spec:
   accessModes:

--- a/charts/denpa/values.yaml
+++ b/charts/denpa/values.yaml
@@ -104,7 +104,15 @@ prepull:
 persistence:
   # 既定の StorageClass。空ならクラスタの既定
   storageClassName: ""
-  # PVC は ArgoCD に消させない (Prune=false,Delete=false)。ここが消えると録画が消える
+  # **PVC を ArgoCD に消させない** (Prune=false,Delete=false)。ここが消えると録画が消える
+  # ので既定は true。true の間は、chart から PVC が消えても・Application ごと消しても
+  # ArgoCD は PVC に触らない。
+  #
+  # **false にすると「git で消したものは実際に消える」。** マニフェストから PVC が
+  # 外れた時点でボリュームごと消えるので、後ろ盾になるバックアップを用意してから
+  # にすること (このリポジトリ自身は日次の restic があるので false — deploy/application.yaml)
+  protectFromPruning: true
+  # denpa の DB
   data:
     size: 5Gi
     existingClaim: ""

--- a/deploy/application.yaml
+++ b/deploy/application.yaml
@@ -63,6 +63,10 @@ spec:
 
         persistence:
           storageClassName: local-path-retain
+          # **「git で消したものは消える」を優先する** という判断
+          # (danything/gitops の docs/decisions.md「PVC を守る仕掛けをやめた」)。
+          # 後ろ盾は日次の restic (R2) で、復元リハーサルは通っている
+          protectFromPruning: false
 
         # Cilium Gateway (danything/gitops の bootstrap/gateway/) に付ける。
         # dp.doany.io は `*.doany.io` の、dp.l.doany.io は `*.l.doany.io` の


### PR DESCRIPTION
## なぜ

**「git で消したものは実際に消える」を優先する**、という判断(本人)。
PVC に付いていた `argocd.argoproj.io/sync-options: Prune=false,Delete=false` が
ある限り、マニフェストを git から消しても PVC と中の実データはクラスタに残り続ける。
GitOps の一貫性を損なうので、この家では外す。

守りを外す根拠はバックアップ。`/var/lib/rancher/k3s/storage`(= local-path-retain の
PVC データ)は日次の restic で Cloudflare R2 に入っているので、**誤って消したときの
最大損失は 24 時間ぶん**。**この判断は復元リハーサルが通ってから**行った
(danything/gitops の `docs/restore-drill.md`)。通らなければ守りを外す根拠が無かった。

## なぜ「削除」ではなく「値」にしたか

**このリポジトリの chart は外に配っている**(`oci://ghcr.io/danything/charts/denpa`、
`.../denpa-agent`)。テンプレートのコメントが言うとおり「ここが消えると録画が消える」ので、
**知らない人が初めて入れる環境では、この守りは妥当な既定値**。
自分の家の都合で他人の既定値を黙って取り上げるのは違う。

なので、削除ではなく **`persistence.protectFromPruning` という値**にして、
**既定を `true`** に置いた。既存の利用者から見れば出力は 1 行も変わらない。
外したい人(=バックアップを持っていて、GitOps の一貫性のほうを取る人)だけが
`false` にする。値の意味は `values.yaml` にコメントで書いてある。

## 変更

- `charts/denpa/templates/pvc.yaml` — 4 本 (`agent-config` / `denpa-data` /
  `denpa-recorded` / `denpa-library`) の注釈を `{{- if $root.Values.persistence.protectFromPruning }}` で囲った
- `charts/denpa-agent/templates/pvc.yaml` — 2 本 (`agent-config` / `denpa-recorded`) を同様に
- `charts/denpa/values.yaml`, `charts/denpa-agent/values.yaml` —
  `persistence.protectFromPruning: true` を追加し、周りと同じコメントの書き方で説明
- `deploy/application.yaml` — **この家のぶんだけ `false`**。判断の出典もコメントに書いた

`helm.sh/resource-policy: keep` は値に関わらず**そのまま**残る(Helm の uninstall に
巻き込ませないための別の話で、ArgoCD の prune とは関係が無い)。

## 確かめたこと

`helm template` で両方向を確認した。

| | denpa | denpa-agent |
| --- | --- | --- |
| 既定 (値を渡さない) | 注釈 **4 本ぶん出る** | 注釈 **2 本ぶん出る** |
| `--set persistence.protectFromPruning=false` | **消える** | **消える** |
| `deploy/application.yaml` の values をそのまま渡す | **消える**(`helm.sh/resource-policy: keep` と `storageClassName: local-path-retain` は残る) | — |

`helm lint` は両 chart とも通る(`icon is recommended` の INFO のみ)。

テストは `package.json` のものを一式:

- `bun run lint` (biome) — 295 ファイル、指摘なし
- `bun run check` (svelte-check) — 950 ファイル、0 errors / 0 warnings
- `bun run test:unit` — **826 pass / 0 fail**(2245 expect)
- `bunx playwright test` — **149 passed / 1 flaky**。flaky は
  `01-dashboard.spec.ts`「番組表はグリッドで出て、キーワード検索ではリストになる」で
  ハイドレーション待ちのタイムアウト、リトライで通る。**この PR はアプリのコードを
  1 行も触っていない**(chart の YAML だけ)ので無関係

## 承知しておくこと

- `Delete=false` も外れるので、**ArgoCD の Application を消すと PVC も消える**。
  マニフェストの削除は git のレビューを通るが、Application の削除は UI のボタン
  1 つで済む、という重みの差は残る
- **`denpa-recorded` は restic の対象外**(`backup/k3s-backup` が
  `*_denpa_denpa-recorded` を除外している)。エンコード前の作業領域で、終われば消える
  置き場なので意図どおりだが、**ここだけは消したら戻らない**。エンコード済みの
  `denpa-library` は対象に入っている
- `storageClassName: local-path-retain` はそのまま — バインド済みの PVC では
  変更も削除もできない(API が拒否する)。挙動は PV 側の
  `persistentVolumeReclaimPolicy` を `Retain` → `Delete` にパッチして揃えてある

出典: danything/gitops#65 / `docs/decisions.md`「PVC を守る仕掛けをやめた」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv
