### PR TITLE
Secret 更新時に Pod を入れ替える (auto-reload 注釈)

### DIFF
--- a/charts/denpa/templates/denpa.yaml
+++ b/charts/denpa/templates/denpa.yaml
@@ -3,6 +3,16 @@ kind: Deployment
 metadata:
   name: denpa
   namespace: {{ .Release.Namespace }}
+  annotations:
+    # **Secret が変わったら Pod を入れ替える。** これが無いと、Infisical で
+    # OIDC_GROUP などを直しても**動いている Pod は古い値を掴んだまま**になる。
+    # 実際に起きた: Entra の admins グループを消してアプリロールへ移した際、
+    # OIDC_GROUP が消えたグループの ID のまま残り、誰もログインできない状態に
+    # 気づかれず置かれていた (2026-09-07)。
+    #
+    # 入れ替えは strategy: Recreate と grace period 21900s に従うので、
+    # 録画中は古い Pod が録画を終えるまで居座り、そのあと切り替わる。
+    secrets.infisical.com/auto-reload: "true"
   labels:
     {{- include "denpa.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
`charts/denpa` の Deployment に `secrets.infisical.com/auto-reload: "true"` を足す。

## なぜ

**これが無いと、Infisical で値を直しても動いている Pod は古い値を掴んだままになる。**

実際に起きた（2026-09-07）:

1. Entra の `admins` グループを削除してアプリロール `admin` に移行
2. `/shared/entra` の `admins-group` が消えたグループのオブジェクト ID のまま残る
3. `allowed()` は `groups ∪ roles`（= `["admin"]`）から `5847ec59-...` を探して空振り → **全員拒否**
4. 値を直しても Pod が入れ替わらず、`OIDC_GROUP` は古いまま。手で `rollout restart` して解消

実装（`src/lib/server/oidc.ts` の `allowed()`）は正しく動いていた。壊れていたのは設定の反映経路。

## 副作用

入れ替えは `strategy: Recreate` と `terminationGracePeriodSeconds: 21900` に従う。録画中に Secret が変わった場合、古い Pod が録画を終えるまで居座り、そのあと切り替わる。新旧 2 Pod がチューナーと PVC を取り合うことはない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv