### PR TITLE
k8up の backupcommand を足す(SQLite の整合したコピー)

### DIFF
--- a/charts/denpa/templates/denpa.yaml
+++ b/charts/denpa/templates/denpa.yaml
@@ -17,11 +17,24 @@ spec:
     metadata:
       labels:
         app: denpa
-      {{- with .Values.imageMarks.denpa }}
       annotations:
+        # k8up が Pod の中でこれを走らせて、標準出力に出たものを保存する。
+        # serialize() は SQLite の pager を通して読むので、書き込みが続いていても
+        # 1 つのコミット済みの状態が出る。ファイルをそのままコピーすると
+        # denpa.db と denpa.db-wal が別々の瞬間のものになりうる (WAL は 5 MB ある) ──
+        # ホスト側のバックアップが先に scale down しているのはそのためで、
+        # ノードが Talos になるとシェルが無いのでその形は取れない。
+        #
+        # bun:sqlite は既に入っているランタイムの機能なので、イメージには何も足さない。
+        # スクリプトに空白を入れないこと: k8up は注釈をシェル風に分割するので、
+        # 引用符が効くのは -e の前後 2 か所だけで済ませる。
+        k8up.io/backupcommand: >-
+          bun -e 'process.stdout.write(new(require("bun:sqlite").Database)("/app/data/denpa.db",{readonly:true}).serialize())'
+        k8up.io/file-extension: .db
+        {{- with .Values.imageMarks.denpa }}
         # 入れ替えの合図 (values.yaml の imageMarks)
         denpa.doany.io/denpa-image: {{ . | quote }}
-      {{- end }}
+        {{- end }}
     spec:
       # 録画中に入れ替えが来たら、終わるまで居座ってから止まる (SHUTDOWN_WAIT)
       terminationGracePeriodSeconds: {{ .Values.denpa.terminationGracePeriodSeconds }}


### PR DESCRIPTION
Talos に移るとノードにシェルが無くなるので、いまホスト側がやっている
「scale down → PVC のディレクトリを restic に流す」形は使えなくなる。
k8up は Pod の中でコマンドを走らせて**標準出力を保存**できるので、そちらに寄せる。

`denpa.db` は 20 MB、`denpa.db-wal` は 5 MB ある。ファイルをそのままコピーすると
この 2 つが別々の瞬間のものになりうる。`serialize()` は SQLite の pager を通して読むので、
**書き込みが続いていても 1 つのコミット済みの状態**が出る。

**イメージには何も足さない。** `bun:sqlite` は既に入っているランタイムの機能。

## 本番の Pod で実測

```
bytes=20598784 live_rows=30309 copy_rows=30309 tables=12 integrity=ok
```

`live_rows` は今の DB、`copy_rows` はコピーを開き直して数えたもの。標準出力に出る量も同じ 20598784 バイト。

## チャート側の変更

`annotations` は `imageMarks.denpa` の `with` の中にあったので、値が空だとブロックごと消えていた。
k8up の注釈は常に要るので、ブロックを条件の外に出して `imageMarks` の行だけ `with` に残した。

```
$ helm template charts/denpa --set imageMarks.denpa=abc123
{'k8up.io/backupcommand': ..., 'k8up.io/file-extension': '.db', 'denpa.doany.io/denpa-image': 'abc123'}
$ helm template charts/denpa
{'k8up.io/backupcommand': ..., 'k8up.io/file-extension': '.db'}
```

## 反映するとローリング再起動が 1 回入る

Pod テンプレートの注釈が変わるため。`terminationGracePeriodSeconds` と `SHUTDOWN_WAIT` があるので
録画中なら終わるまで待つ。

## いま何も起きないこと

`denpa` namespace に k8up の `Schedule` はまだ無いので、注釈は**それ単体では何も動かさない**。
Schedule は gitops 側で足す。バックアップは引き続きホストのスクリプトが取っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv