### PR TITLE
ファイルの PVC を k8up に取らせる

### DIFF
--- a/charts/denpa/templates/pvc.yaml
+++ b/charts/denpa/templates/pvc.yaml
@@ -4,11 +4,21 @@
 existingClaim を渡したものは作らない
 */ -}}
 {{- $root := . -}}
+{{- /*
+`k8up` は k8up にファイルとして取らせるかどうか。operator が
+BACKUP_SKIP_WITHOUT_ANNOTATION=true なので、**注釈そのものが「取る」という宣言**になる。
+`k8upArgs` は restic に足す引数(JSON の配列)。
+*/ -}}
 {{- range $item := list
-    (dict "key" "agentConfig" "name" "agent-config" "note" "エージェントの設定 (tuners.json / channels.json)。denpa の画面から書く")
-    (dict "key" "data" "name" "denpa-data" "note" "denpa の DB")
-    (dict "key" "recorded" "name" "denpa-recorded" "note" "生TSの作業領域。エンコードが終われば消える")
-    (dict "key" "library" "name" "denpa-library" "note" "エンコード済みの置き場。denpa がここから配り、削除も denpa がやる")
+    (dict "key" "agentConfig" "name" "agent-config" "k8up" "true"
+          "note" "エージェントの設定 (tuners.json / channels.json)。denpa の画面から書く")
+    (dict "key" "data" "name" "denpa-data" "k8up" "true"
+          "k8upArgs" "[\"--exclude\",\"denpa.db*\"]"
+          "note" "denpa の DB と logos/。DB は Pod 側の backupcommand で取るので除外し、logos/ だけをファイルとして取る")
+    (dict "key" "recorded" "name" "denpa-recorded" "k8up" "false"
+          "note" "生TSの作業領域。エンコードが終われば消える。容量が大きく数時間で入れ替わるので取らない")
+    (dict "key" "library" "name" "denpa-library" "k8up" "true"
+          "note" "エンコード済みの置き場。denpa がここから配り、削除も denpa がやる")
 }}
 {{- $p := index $root.Values.persistence $item.key }}
 {{- if not $p.existingClaim }}
@@ -26,6 +36,10 @@ metadata:
     argocd.argoproj.io/sync-options: Prune=false,Delete=false
     {{- end }}
     helm.sh/resource-policy: keep
+    k8up.io/backup: {{ $item.k8up | quote }}
+    {{- with $item.k8upArgs }}
+    k8up.io/backup-restic-args: {{ . | quote }}
+    {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Talos にはシェルが無いので、ホストの `backup/k3s-backup` が全 PVC を写す形は持っていけません。DB は #84 で k8up の `backupcommand` に寄せたので、残るファイルの PVC に注釈を足します。

```
$ helm template denpa charts/denpa
  agent-config     backup=true   args=-
  denpa-data       backup=true   args=["--exclude","denpa.db*"]
  denpa-recorded   backup=false  args=-
  denpa-library    backup=true   args=-
```

## `denpa-data` だけ除外が要る

DB（`denpa.db`）とファイル（`logos/`）が同じ PVC に同居しています。素直に `"true"` を付けると、**整合したコピー（`backupcommand` の `serialize()`）と壊れかけのファイルコピーの両方**がリポジトリに入ってしまいます。`k8up.io/backup-restic-args` で `denpa.db*` を除外して、`logos/` だけをファイルとして取ります。

## `denpa-recorded` は取りません

生 TS の作業領域で、いま 14 GB あり数時間で入れ替わります。**ここが育って R2 の無料枠 10 GB を超えたことがある**ので、明示的に `"false"` にしています（ホストのスクリプトも `--exclude` していました）。

## テンプレート側の変更

`list` の各 dict に `k8up` と `k8upArgs` を足しました。PVC ごとの判断が 1 か所で読めます。

**PVC のメタデータだけの変更なので Pod は再起動しません。**

## 同じ形は本番で確認済み

adguardhome の 3 本と netbird の routing-peer は既に成功しています。

```
1  host=adguardhome  tags=['k8up'] path=/data/adguardhome-conf
1  host=netbird      tags=['k8up'] path=/data/netbird-routing-peer-data
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgGYf5qbjDXYhtzcpLsGvv