### PR TITLE
chore(renovate): dotnet/sdk は正式版 (<11) に留める

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,12 @@
       "allowedVersions": "<6"
     },
     {
+      "description": "dotnet/sdk の浮動の major 札 (`11.0`) は正式版より前からあり、11月の GA まではプレビューを指す (2026-09 時点で中身は 11.0.100-preview.1)。しかも CI はこの Dockerfile を焼かないので、緑のまま通ってしまう。正式版が出たら上限を上げて、TargetFramework も一緒に上げる",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["mcr.microsoft.com/dotnet/sdk"],
+      "allowedVersions": "<11"
+    },
+    {
       "description": "CM検出の一式は毎週書き換わっている。まとめて1本の PR にして、上げるときは実機で確かめる",
       "matchDepNames": [
         "https://github.com/tobitti0/dtvindex",


### PR DESCRIPTION
Renovate が `mcr.microsoft.com/dotnet/sdk` を `10.0` → `11.0` に上げる PR (#88) を出しましたが、**.NET 11 はまだ preview です**。MCR の札を引くと 11 系の実体は `11.0.100-preview.1` しかなく、`11.0` という浮動の札がそこを指しています (GA は例年11月)。

さらに **CI の緑はこの変更を見ていません** — `agent` ジョブは `actions/setup-dotnet` の `10.0.x` で `dotnet test` と適合テストを回すだけで、`agent/Dockerfile` を焼きません。焼かれるのは main に入ったあとの build-and-deploy なので、壊れるとしたらマージ後です。

typescript を `<6` に留めている既存の規則と同じ形で、`dotnet/sdk` を `<11` に留めます。**GA が出たら上限を上げて、`TargetFramework` (`net10.0`) も一緒に上げます。**

この規則が入ると Renovate は #88 を自分で閉じます (条件から外れた PR は閉じる)。閉じても上限を外せばまた出してくるので、GA のときに気付けないことはありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)